### PR TITLE
feat: Style the topic tree and filter data items shown based on topic selection

### DIFF
--- a/package.json
+++ b/package.json
@@ -18,7 +18,6 @@
     "@fortawesome/vue-fontawesome": "^0.1.2",
     "@molgenis/molgenis-api-client": "^3.1.0",
     "bootstrap-vue": "^2.0.0-rc.11",
-    "bootstrap-vue-treeview": "^1.0.8",
     "vue": "^2.5.17",
     "vue-router": "^3.0.1",
     "vuex": "^3.0.1"

--- a/src/components/TopicTree.vue
+++ b/src/components/TopicTree.vue
@@ -1,22 +1,32 @@
 <template>
-  <b-tree-view :data="topicTree"
-               :contextMenu="false"
-               :renameNodeOnDblClick="false"
-               nodeLabelProp="label"></b-tree-view>
+  <b-list-group>
+    <b-list-group-item v-for="topic in topicList"
+                       :key="topic.id"
+                       :button="true"
+                       :variant="topic.children.length ? 'secondary' : 'default'"
+                       :active="topic.selected"
+                       @click="topicClick(topic)">
+      {{topic.label}}
+    </b-list-group-item>
+  </b-list-group>
 </template>
 <script>
-  import { mapGetters } from 'vuex'
+import { mapGetters, mapMutations } from 'vuex'
 
-  export default {
-    name: 'Topic',
-    computed: {
-      ...mapGetters(['topicTree'])
-    },
-    props: {
-      topics: {
-        type: Array,
-        required: true
+export default {
+  name: 'Topic',
+  methods: {
+    topicClick (topic) {
+      if (topic.children.length) {
+        this.toggleTopicOpen(topic.id)
+      } else {
+        this.toggleTopicSelect(topic.id)
       }
-    }
+    },
+    ...mapMutations(['toggleTopicSelect', 'toggleTopicOpen'])
+  },
+  computed: {
+    ...mapGetters(['topicList'])
   }
+}
 </script>

--- a/src/main.ts
+++ b/src/main.ts
@@ -6,8 +6,6 @@ import store from './store/store'
 import BootstrapVue from 'bootstrap-vue'
 import '@/assets/lifelines_bs4.css'
 import 'bootstrap-vue/dist/bootstrap-vue.css'
-// @ts-ignore
-import BootstrapVueTreeview from 'bootstrap-vue-treeview/dist/bootstrap-vue-treeview.esm.js'
 
 import { library } from '@fortawesome/fontawesome-svg-core'
 import { faQuestionCircle, faSave, faUndo, faSearch } from '@fortawesome/free-solid-svg-icons'
@@ -19,7 +17,6 @@ Vue.component('font-awesome-icon', FontAwesomeIcon)
 Vue.config.productionTip = false
 
 Vue.use(BootstrapVue)
-Vue.use(BootstrapVueTreeview)
 
 new Vue({
   router,

--- a/src/store/getters.ts
+++ b/src/store/getters.ts
@@ -13,6 +13,8 @@ export default {
     const toVueTopic = (topic: Topic): VueTopic => ({
       id: topic.id,
       label: topic.label,
+      open: state.openTopics.includes(topic.id),
+      selected: state.selectedOptions.topic === topic.id,
       children: state.topics
         .filter(child => child.parentTopicId === topic.id)
         .filter(child => child.id !== topic.id)
@@ -21,6 +23,11 @@ export default {
     return state.topics
       .filter(isRootTopic)
       .map(toVueTopic)
+  },
+  topicList: (state: ApplicationState, getters: {topicTree: VueTopic[]}): VueTopic[] => {
+    const treeWalker = (previous: VueTopic[], current: VueTopic): VueTopic[] =>
+      current.open ? current.children.reduce(treeWalker,[...previous, current]) : [...previous, current]
+    return getters.topicTree.reduce(treeWalker, [] as VueTopic[])
   },
   vueDataItems: (state: ApplicationState): VueDataItem[] =>
       state.dataItems.map(item => ({

--- a/src/store/getters.ts
+++ b/src/store/getters.ts
@@ -39,5 +39,7 @@ export default {
         topic: lookup([item.topic], state.topics)[0],
         selected: state.selectedDataItems.includes(item.id),
         enabled: true
-      }))
+      })).filter(item =>
+        !state.selectedOptions.topic || state.selectedOptions.topic === item.topic.id
+      )
 }

--- a/src/store/mutations.ts
+++ b/src/store/mutations.ts
@@ -30,5 +30,18 @@ export default {
 
   setCollectionPoints (state: ApplicationState, collectionPoints: CategoricalFacet) {
     state.categoricalFacets.collectionPoint = collectionPoints
+  },
+
+  toggleTopicSelect (state: ApplicationState, id: string) {
+    state.selectedOptions.topic = state.selectedOptions.topic === id ? undefined : id
+  },
+
+  toggleTopicOpen (state: ApplicationState, id: string) {
+    const index = state.openTopics.indexOf(id)
+    if (index === -1) {
+      state.openTopics.push(id)
+    } else {
+      state.openTopics.splice(index, 1)
+    }
   }
 }

--- a/src/store/state.ts
+++ b/src/store/state.ts
@@ -14,8 +14,10 @@ const state: ApplicationState = {
     sexGroup: [],
     subCohorts: [],
     collectionPoint: ['baseline'],
+    topic: undefined,
     searchTerm: 'hallo, ik sta in de state'
   },
+  openTopics: [],
   selectedDataItems: ['var1']
 }
 

--- a/src/types/store.ts
+++ b/src/types/store.ts
@@ -43,9 +43,11 @@ export interface ApplicationState {
     sexGroup: string[];
     subCohorts: string[];
     collectionPoint: string[];
+    topic?: string
     searchTerm: string;
   }
   selectedDataItems: string[]
+  openTopics: string[]
 }
 
 export default ApplicationState

--- a/src/types/vue.ts
+++ b/src/types/vue.ts
@@ -14,5 +14,7 @@ export interface VueDataItem {
 
 export interface VueTopic extends Identifiable {
   label: string,
-  children: VueTopic[]
+  children: VueTopic[],
+  selected: boolean,
+  open: boolean
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -1172,7 +1172,7 @@ babel-polyfill@6.23.0:
     core-js "^2.4.0"
     regenerator-runtime "^0.10.0"
 
-babel-runtime@^6.11.6, babel-runtime@^6.22.0, babel-runtime@^6.26.0:
+babel-runtime@^6.11.6, babel-runtime@^6.22.0:
   version "6.26.0"
   resolved "https://registry.yarnpkg.com/babel-runtime/-/babel-runtime-6.26.0.tgz#965c7058668e82b55d7bfe04ff2337bc8b5647fe"
   dependencies:
@@ -1263,15 +1263,6 @@ bonjour@^3.5.0:
 boolbase@^1.0.0, boolbase@~1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/boolbase/-/boolbase-1.0.0.tgz#68dff5fbe60c51eb37725ea9e3ed310dcc1e776e"
-
-bootstrap-vue-treeview@^1.0.8:
-  version "1.0.8"
-  resolved "https://registry.yarnpkg.com/bootstrap-vue-treeview/-/bootstrap-vue-treeview-1.0.8.tgz#c3a79e55f83e52ebdfa4ea657bfe54cd4bfd4334"
-  integrity sha512-750ojAtRU7/f7M3xx7XCqQPYoHMN1ATjzW1pWkJdxl1SOO3zksAdrRha77r85SUSJxwmV4jPvXOvfO4+ohaDEw==
-  dependencies:
-    babel-runtime "^6.26.0"
-    vue "^2.2.2"
-    vue-context-menu "^2.0.6"
 
 bootstrap-vue@^2.0.0-rc.11:
   version "2.0.0-rc.11"
@@ -6182,11 +6173,6 @@ vm-browserify@0.0.4:
   dependencies:
     indexof "0.0.1"
 
-vue-context-menu@^2.0.6:
-  version "2.0.6"
-  resolved "https://registry.yarnpkg.com/vue-context-menu/-/vue-context-menu-2.0.6.tgz#185107cd3ae51f25c53266a2751008fa7da4f34e"
-  integrity sha512-wTyyjWbrGq/Rc1iivHl9ryI0IcsodRgg46CAGCm6knADDsTj5qJzo2pPDfi6y2nQreg8llJC2lGGts88tMX1sQ==
-
 vue-functional-data-merge@^2.0.5:
   version "2.0.7"
   resolved "https://registry.yarnpkg.com/vue-functional-data-merge/-/vue-functional-data-merge-2.0.7.tgz#bdee655181eacdcb1f96ce95a4cc14e75313d1da"
@@ -6227,7 +6213,7 @@ vue-template-es2015-compiler@^1.6.0:
   version "1.6.0"
   resolved "https://registry.yarnpkg.com/vue-template-es2015-compiler/-/vue-template-es2015-compiler-1.6.0.tgz#dc42697133302ce3017524356a6c61b7b69b4a18"
 
-vue@^2.2.2, vue@^2.5.17:
+vue@^2.5.17:
   version "2.5.17"
   resolved "https://registry.yarnpkg.com/vue/-/vue-2.5.17.tgz#0f8789ad718be68ca1872629832ed533589c6ada"
 


### PR DESCRIPTION
Flatten the tree to a list and render it as an item group.
Ditch the icons and indentation for as long as the tree is only two levels deep.
Store the topic selection and topic open/close state in the store.