### PR TITLE
Feature/complex age filter

### DIFF
--- a/jest.config.js
+++ b/jest.config.js
@@ -16,7 +16,8 @@ module.exports = {
     '/node_modules/'
   ],
   moduleNameMapper: {
-    '^@/(.*)$': '<rootDir>/src/$1'
+    '^@/(.*)$': '<rootDir>/src/$1',
+    '^.+.(css|styl|less|sass|scss|png|jpg|ttf|woff|woff2)$': 'jest-transform-stub'
   },
   snapshotSerializers: [
     'jest-serializer-vue'

--- a/package.json
+++ b/package.json
@@ -10,6 +10,9 @@
     "test:unit": "vue-cli-service test:unit"
   },
   "dependencies": {
+    "@fortawesome/fontawesome-svg-core": "^1.2.18",
+    "@fortawesome/free-solid-svg-icons": "^5.8.2",
+    "@fortawesome/vue-fontawesome": "^0.1.6",
     "@molgenis/molgenis-api-client": "^3.1.0",
     "@molgenis/molgenis-i18n-js": "^0.1.1",
     "core-js": "2.6.8",

--- a/package.json
+++ b/package.json
@@ -10,14 +10,15 @@
     "test:unit": "vue-cli-service test:unit"
   },
   "dependencies": {
-    "@fortawesome/fontawesome-svg-core": "^1.2.18",
-    "@fortawesome/free-solid-svg-icons": "^5.8.2",
+    "@fortawesome/fontawesome-svg-core": "^1.2.19",
+    "@fortawesome/free-solid-svg-icons": "^5.9.0",
     "@fortawesome/vue-fontawesome": "^0.1.6",
     "@molgenis/molgenis-api-client": "^3.1.0",
     "@molgenis/molgenis-i18n-js": "^0.1.1",
     "core-js": "2.6.8",
     "vue": "^2.6.10",
     "vue-router": "^3.0.3",
+    "vue-slider-component": "^3.0.32",
     "vuex": "^3.0.1"
   },
   "devDependencies": {

--- a/src/components/animations/CollapseTreeIcon.vue
+++ b/src/components/animations/CollapseTreeIcon.vue
@@ -1,0 +1,34 @@
+<template>
+  <font-awesome-icon
+    icon="caret-right"
+    class="collapse-tree-icon"
+    :style="iconStyle"
+  />
+</template>
+
+<script>
+import Vue from 'vue'
+import { library } from '@fortawesome/fontawesome-svg-core'
+import { faCaretRight } from '@fortawesome/free-solid-svg-icons'
+import { FontAwesomeIcon } from '@fortawesome/vue-fontawesome'
+library.add(faCaretRight)
+
+export default Vue.extend({
+  name: 'CollapseTreeIcon',
+  components: { FontAwesomeIcon },
+  props: {
+    state: {
+      type: Boolean,
+      required: true
+    }
+  },
+  computed: {
+    iconStyle () {
+      return {
+        transform: `rotate(${this.state ? 90 : 0}deg)`,
+        transition: 'transform 0.2s'
+      }
+    }
+  }
+})
+</script>

--- a/src/components/animations/TransitionExpand.vue
+++ b/src/components/animations/TransitionExpand.vue
@@ -1,0 +1,82 @@
+<template>
+  <transition
+    name="expand"
+    @enter="enter"
+    @after-enter="afterEnter"
+    @leave="leave"
+  >
+    <slot/>
+  </transition>
+</template>
+
+<script>
+// https://github.com/maoberlehner/transition-to-height-auto-with-vue
+// https://markus.oberlehner.net/blog/transition-to-height-auto-with-vue/
+
+export default {
+  name: `TransitionExpand`,
+  methods: {
+    afterEnter (element) {
+      element.style.height = 'auto'
+    },
+    enter (element) {
+      const { width } = getComputedStyle(element)
+
+      element.style.width = width
+      element.style.position = 'absolute'
+      element.style.visibility = 'hidden'
+      element.style.height = 'auto'
+
+      const { height } = getComputedStyle(element)
+
+      element.style.width = null
+      element.style.position = null
+      element.style.visibility = null
+      element.style.height = 0
+
+      // Force repaint to make sure the
+      // animation is triggered correctly.
+      // eslint-disable-next-line no-unused-expressions
+      getComputedStyle(element).height
+
+      setTimeout(() => {
+        element.style.height = height
+      })
+    },
+    leave (element) {
+      const { height } = getComputedStyle(element)
+
+      element.style.height = height
+
+      // Force repaint to make sure the
+      // animation is triggered correctly.
+      // eslint-disable-next-line no-unused-expressions
+      getComputedStyle(element).height
+
+      setTimeout(() => {
+        element.style.height = 0
+      })
+    }
+  }
+}
+</script>
+
+<style scoped>
+  * {
+    will-change: height;
+    transform: translateZ(0);
+    backface-visibility: hidden;
+    perspective: 1000px;
+  }
+
+  .expand-enter-active,
+  .expand-leave-active {
+    transition: height 0.2s ease-in-out;
+    overflow: hidden;
+  }
+
+  .expand-enter,
+  .expand-leave-to {
+    height: 0;
+  }
+</style>

--- a/src/components/facets/AgeFacet.vue
+++ b/src/components/facets/AgeFacet.vue
@@ -1,0 +1,82 @@
+<template>
+  <div class="facet">
+      <label class="age-at-label"  v-if="label" for="age-at-select">Age at</label>
+      <select
+      id="age-at-select"
+      class="custom-select custom-select-sm"
+      v-model="selectedAgeAt"
+      >
+        <option  :value="option.value" v-for="option in ageAtOptions" :key=option.value>
+          {{ option.text }}
+        </option>
+      </select>
+      <toggle-facet facetId="age-group" :options="ageGroupOptions" v-model="selectedAgeGroups" />
+  </div>
+</template>
+
+<script>
+import Vue from 'vue'
+import ToggleFacet from './ToggleFacet.vue'
+
+export default Vue.extend({
+  name: 'AgeFacet',
+  components: { ToggleFacet },
+  props: {
+    facetId: {
+      type: String,
+      required: true
+    },
+    label: {
+      type: String,
+      required: false
+    },
+    ageAtOptions: {
+      type: Array,
+      required: true
+    },
+    ageGroupOptions: {
+      type: Array,
+      required: true
+    },
+    value: {
+      type: Object,
+      required: true
+    }
+  },
+  data: function () {
+    const passedAgeGroup = Object.values(this.value).find(selectedGroups => selectedGroups.length)
+    const passedAgeAt = Object.keys(this.value).find(selectedAssessment => this.value[selectedAssessment].length)
+    return {
+      selectedAgeGroups: passedAgeGroup || [],
+      selectedAgeAt: passedAgeAt || this.ageAtOptions[0].value
+    }
+  },
+  watch: {
+    selectedAgeGroups () {
+      this.handleAgeAtChange()
+    },
+    selectedAgeAt () {
+      this.handleAgeAtChange()
+    }
+  },
+  methods: {
+    handleAgeAtChange () {
+      const selectedAgeAt = this.ageAtOptions.reduce((accum, option) => {
+        accum[option.value] = (option.value === this.selectedAgeAt) ? this.selectedAgeGroups : []
+        return accum
+      }, {})
+      this.$emit('input', selectedAgeAt)
+    }
+  }
+})
+</script>
+
+<style>
+.age-at-label {
+  margin-right: 1rem;
+}
+
+.age-at-container {
+  margin-bottom: 1rem;
+}
+</style>

--- a/src/components/facets/FacetContainer.vue
+++ b/src/components/facets/FacetContainer.vue
@@ -1,0 +1,68 @@
+<template>
+  <div class="facet-container">
+      <label
+        v-if="label"
+        @click="handleFacetToggle"
+         >
+        {{ label }}
+        <font-awesome-icon
+          icon="chevron-up"
+          v-if="collapsable"
+          :class="{ 'fa-rotate-180': collapsed}"
+        />
+      </label>
+      <div v-show="!collapsed" class="facet-container-content">
+       <slot></slot>
+      </div>
+  </div>
+</template>
+
+<script>
+import Vue from 'vue'
+
+export default Vue.extend({
+  name: 'FacetContainer',
+  props: {
+    facetId: {
+      type: String,
+      required: true
+    },
+    label: {
+      type: String,
+      required: false
+    },
+    collapsable: {
+      type: Boolean,
+      required: false,
+      default: () => false
+    },
+    collapsed: {
+      type: Boolean,
+      required: false,
+      default: () => false
+    }
+  },
+  methods: {
+    handleFacetToggle () {
+      if (!this.collapsable) {
+        return
+      }
+      this.$emit('facetToggle', {
+        facetId: this.facetId,
+        collapsed: this.collapsed
+      }
+      )
+    }
+  }
+})
+</script>
+
+<style scoped>
+  .facet-container {
+    margin-bottom: 1rem;
+  }
+
+  label {
+    cursor: grab;
+  }
+</style>

--- a/src/components/facets/FacetOption.vue
+++ b/src/components/facets/FacetOption.vue
@@ -1,7 +1,7 @@
 <template>
     <button
     type="button"
-    class="ll-facet-option btn"
+    class="ll-facet-option btn btn-sm"
     :class="{ 'btn-secondary': !!isSelected, 'btn-outline-secondary': !isSelected }"
     @click.stop="$emit('facetToggled')"
     >

--- a/src/components/facets/RangeFacet.vue
+++ b/src/components/facets/RangeFacet.vue
@@ -1,0 +1,104 @@
+<template>
+  <div class="facet range-facet">
+    <label v-if="label" :for="rangeFacetId">{{ label }}</label>
+    <form>
+      <div class="d-flex justify-content-between">
+          <input
+            type="number"
+            class="range-input form-control form-control-sm"
+            placeholder="From"
+            v-model="sliderValue[0]"
+            @change="handleFromChange"
+          >
+          <input
+            type="number"
+            class="range-input form-control form-control-sm "
+            placeholder="Until"
+            v-model="sliderValue[1]"
+            @change="handleUntilChange"
+          >
+      </div>
+    </form>
+    <div class="slider-container">
+      <vue-slider
+        :id="rangeFacetId"
+        v-model="sliderValue"
+        :min="min"
+        :max="max"
+        @change="handleSliderChange"
+      />
+    </div>
+  </div>
+</template>
+
+<script>
+import Vue from 'vue'
+import VueSlider from 'vue-slider-component'
+import 'vue-slider-component/theme/default.css'
+
+export default Vue.extend({
+  name: 'RangeFacet',
+  components: { VueSlider },
+  props: {
+    facetId: {
+      type: String,
+      required: true
+    },
+    label: {
+      type: String,
+      required: false
+    },
+    min: {
+      type: Number,
+      required: false,
+      default: () => 1900
+    },
+    max: {
+      type: Number,
+      required: false,
+      default: () => 2050
+    },
+    value: {
+      type: Array,
+      default: () => [1900, 2050]
+    }
+  },
+  data: function () {
+    return {
+      sliderValue: this.value.length ? [...this.value] : [1900, 2050]
+    }
+  },
+  computed: {
+    rangeFacetId () {
+      return this.facetId + '-range'
+    }
+  },
+  methods: {
+    handleSliderChange (data) {
+      // clone to break reactive loop
+      this.$emit('input', [parseInt(data[0], 10), parseInt(data[1], 10)])
+    },
+    handleFromChange (data) {
+      this.sliderValue[0] = parseInt(data.currentTarget.value, 10)
+      // clone to break reactive loop
+      this.$emit('input', [...this.sliderValue])
+    },
+    handleUntilChange (data) {
+      this.sliderValue[1] = parseInt(data.currentTarget.value, 10)
+      // clone to break reactive loop
+      this.$emit('input', [...this.sliderValue])
+    }
+  }
+})
+</script>
+
+<style scoped>
+.slider-container {
+  padding-top: 0.5rem;
+  padding-bottom: 0.5rem;
+}
+
+.range-input {
+  width: 4rem;
+}
+</style>

--- a/src/components/facets/ToggleFacet.vue
+++ b/src/components/facets/ToggleFacet.vue
@@ -1,6 +1,6 @@
 <template>
-  <div class="ll-facet-container">
-      <label :for="facetOptionsId">{{ label }}</label>
+  <div class="facet">
+      <label v-if="label" :for="facetOptionsId">{{ label }}</label>
       <ul :id="facetOptionsId" class="list-unstyled list-inline">
           <li class="list-inline-item" v-for="option in options" :key=option.value>
               <facet-option :text="option.text" :isSelected="value.includes(option.value)" @facetToggled="handleFacetToggle(option)"/>
@@ -23,7 +23,7 @@ export default Vue.extend({
     },
     label: {
       type: String,
-      required: true
+      required: false
     },
     options: {
       type: Array,

--- a/src/components/tree/CollapsibleTree.vue
+++ b/src/components/tree/CollapsibleTree.vue
@@ -1,0 +1,106 @@
+<template>
+  <div id="tree-view">
+    <ul class="list-group">
+      <template v-for="parent in structure">
+        <li
+          :key="parent.name"
+          class="list-group-item list-group-item-primary list-group-item-action text-truncate pr-3"
+          :title="parent.name"
+          role="button"
+          @click="toggleCollapse(parent.name)"
+          style="z-index: 1"
+        >
+          <div class="row">
+            <div class="text-truncate col pr-0">
+              <collapse-tree-icon
+                v-if="parent.children && parent.children.length > 0"
+                class="mr-2"
+                :state="parent.name in collapsed"
+              />
+              {{parent.name}}
+            </div>
+            <div class="col-md-auto d-flex align-items-center">
+              <span class="badge badge-pill badge-light float-right align-self-center">{{parent.count}}</span>
+            </div>
+          </div>
+        </li>
+
+        <transition-expand :key="parent.name+'-children'" >
+          <li class="list-group-item p-0" v-if="parent.name in collapsed && parent.children && parent.children.length > 0">
+            <ul class="list-group list-group-flush">
+              <li
+                :class="(value===child.name)&&'active'"
+                class="list-group-item list-group-item-secondary list-group-item-action px-3"
+                role="button"
+                v-for="child in parent.children"
+                :key="child.name"
+                :title="child.name"
+                @click="selectElement(child.name)"
+              >
+                <div class="row">
+                  <div class="text-truncate col pr-0">
+                    {{child.name}}
+                  </div>
+                  <div class="col-md-auto d-flex align-items-center">
+                    <span class="badge badge-pill badge-light float-right align-self-center">{{child.count}}</span>
+                  </div>
+                </div>
+              </li>
+            </ul>
+          </li>
+        </transition-expand>
+      </template>
+    </ul>
+
+  </div>
+</template>
+
+<script>
+import Vue from 'vue'
+import CollapseTreeIcon from '../animations/CollapseTreeIcon.vue'
+import TransitionExpand from '../animations/TransitionExpand.vue'
+
+export default Vue.extend({
+  name: 'CollapsibleTree',
+  data: function () {
+    return {
+      collapsed: this.startOpen()
+    }
+  },
+  props: {
+    value: {
+      type: String,
+      required: true
+    },
+    structure: {
+      type: Array,
+      required: true
+    }
+  },
+  methods: {
+    startOpen () {
+      let toOpen = []
+      this.structure.map((item) => { if (item.open) toOpen[item.name] = true })
+      return toOpen
+    },
+    selectElement (name) {
+      this.$emit('input', name)
+    },
+    toggleCollapse (name) {
+      if (name in this.collapsed) {
+        delete this.collapsed[name]
+      } else {
+        this.collapsed[name] = true
+      }
+      this.$forceUpdate()
+    }
+  },
+  components: { TransitionExpand, CollapseTreeIcon }
+})
+</script>
+
+<style scoped>
+  [role="button"]{
+    cursor: pointer;
+  }
+</style>

--- a/src/main.ts
+++ b/src/main.ts
@@ -4,7 +4,6 @@ import store from './store/store'
 
 // @ts-ignore
 import i18n from '@molgenis/molgenis-i18n-js'
-
 import router from './router'
 
 Vue.config.productionTip = false

--- a/src/main.ts
+++ b/src/main.ts
@@ -1,10 +1,17 @@
 import Vue from 'vue'
 import App from './App.vue'
+import { library } from '@fortawesome/fontawesome-svg-core'
+import { faChevronUp } from '@fortawesome/free-solid-svg-icons'
+import { FontAwesomeIcon } from '@fortawesome/vue-fontawesome'
+
 import store from './store/store'
 
 // @ts-ignore
 import i18n from '@molgenis/molgenis-i18n-js'
 import router from './router'
+
+library.add(faChevronUp)
+Vue.component('font-awesome-icon', FontAwesomeIcon)
 
 Vue.config.productionTip = false
 

--- a/src/store/state.ts
+++ b/src/store/state.ts
@@ -11,9 +11,23 @@ const state: ApplicationState = {
     { value: 'deep', text: 'DEEP' },
     { value: 'dag3', text: 'DAG3' }
   ],
+  ageGroupOptions: [
+    { value: '1', text: '0-17' },
+    { value: '2', text: '18-65' },
+    { value: '3', text: '65+' }
+  ],
+  ageAtOptions: [
+    { value: 'ageGroupAt1A', text: 'baseline' },
+    { value: 'ageGroupAt2A', text: 'second assessment' },
+    { value: 'ageGroupAt3A', text: 'third assessment' }
+  ],
   facetFilter: {
     gender: [],
-    subcohort: []
+    subcohort: [],
+    ageGroupAt1A: [],
+    ageGroupAt2A: [],
+    ageGroupAt3A: [],
+    yearOfBirthRange: []
   },
   sectionList: [],
   subSectionList: [],

--- a/src/store/state.ts
+++ b/src/store/state.ts
@@ -14,7 +14,11 @@ const state: ApplicationState = {
   facetFilter: {
     gender: [],
     subcohort: []
-  }
+  },
+  sectionList: [],
+  subSectionList: [],
+  treeStructure: [],
+  treeSelected: ''
 }
 
 export default state

--- a/src/store/store.ts
+++ b/src/store/store.ts
@@ -2,6 +2,8 @@ import Vue from 'vue'
 import Vuex from 'vuex'
 import state from '@/store/state'
 import ApplicationState from '@/types/ApplicationState'
+// @ts-ignore
+import api from '@molgenis/molgenis-api-client'
 
 Vue.use(Vuex)
 
@@ -13,9 +15,68 @@ export default new Vuex.Store({
     },
     updateSubcohortfilter (state: ApplicationState, selectedSubcohorts: String[]) {
       state.facetFilter.subcohort = selectedSubcohorts
+    },
+    updateTreeSelection (state: ApplicationState, selection: String) {
+      state.treeSelected = selection
+    },
+    updateSection (state: ApplicationState, sections: String[]) {
+      state.sectionList = sections
+    },
+    updateTreeStructure (state: ApplicationState, sections: String[]) {
+      state.treeStructure = sections
+    },
+    updateSubSection (state: ApplicationState, subSections: String[]) {
+      state.subSectionList = subSections
     }
   },
   actions: {
+    loadTreeStructure ({ dispatch, commit } : any) {
+      // Show simple initial tree (only the parents)
+      const sections = api.get('/api/v2/lifelines_section?num=100').then((response: any) => {
+        let sections:String[][] = []
+        response.items.map((item:any) => { sections[item.id] = item.name })
+        commit('updateSection', sections)
 
+        const treeStructure = response.items.map((item:any) => { return { 'name': item.name } })
+        commit('updateTreeStructure', treeStructure)
+        return sections
+      })
+
+      // Request details
+      const subSections = api.get('/api/v2/lifelines_sub_section?num=1000').then((response: any) => {
+        let subSections:String[] = []
+        response.items.map((item:any) => { subSections[item.id] = item.name })
+        commit('updateSection', subSections)
+        return subSections
+      })
+
+      const tree = api.get('/api/v2/lifelines_tree?num=1000').then((response: any) => {
+        let structure:any = {}
+        response.items.map((item:any) => {
+          if (item.section_id.id in structure) {
+            structure[item.section_id.id].push(item.subsection_id.id)
+          } else {
+            structure[item.section_id.id] = [item.subsection_id.id]
+          }
+        })
+
+        let treeStructure:Array<Object> = []
+        for (let [key, value] of Object.entries(structure)) {
+          treeStructure.push({ key: key, list: value })
+        }
+        return treeStructure
+      })
+
+      // Build final tree
+      Promise.all([sections, subSections, tree]).then(([sections, subSections, treeStructure]) => {
+        const final = treeStructure.map((item:any) => {
+          return {
+            name: sections[item.key],
+            children: item.list.map((id:Number) => { return { name: subSections[id] } })
+          }
+        })
+        commit('updateTreeStructure', final)
+      })
+    }
   }
 })

--- a/src/store/store.ts
+++ b/src/store/store.ts
@@ -16,6 +16,22 @@ export default new Vuex.Store({
     updateSubcohortfilter (state: ApplicationState, selectedSubcohorts: String[]) {
       state.facetFilter.subcohort = selectedSubcohorts
     },
+    updateSelectedAgeAt (state: ApplicationState, selectedAgeAt: any) {
+      state.facetFilter.ageGroupAt1A = selectedAgeAt.ageGroupAt1A
+      state.facetFilter.ageGroupAt2A = selectedAgeAt.ageGroupAt2A
+      state.facetFilter.ageGroupAt3A = selectedAgeAt.ageGroupAt3A
+    },
+    updateYearOfBirthRangefilter (state: ApplicationState, yobRange: Number[]) {
+      state.facetFilter.yearOfBirthRange = yobRange
+    },
+    removeYearOfBirthRangefilter (state: ApplicationState) {
+      state.facetFilter.yearOfBirthRange = []
+    },
+    removeAgeAtFilter (state: ApplicationState) {
+      state.facetFilter.ageGroupAt1A = []
+      state.facetFilter.ageGroupAt2A = []
+      state.facetFilter.ageGroupAt3A = []
+	},
     updateTreeSelection (state: ApplicationState, selection: String) {
       state.treeSelected = selection
     },

--- a/src/types/applicationState.ts
+++ b/src/types/applicationState.ts
@@ -1,10 +1,14 @@
 import ToggleFacetOption from '@/types/toggleFacetOption'
 
 export default interface ApplicationState {
-    genderOptions: ToggleFacetOption[],
-    subcohortOptions: ToggleFacetOption[],
-    facetFilter: {
-      gender: String[],
-      subcohort: String[]
-    }
-  }
+  genderOptions: ToggleFacetOption[],
+  subcohortOptions: ToggleFacetOption[],
+  facetFilter: {
+    gender: String[],
+    subcohort: String[]
+  },
+  sectionList: String[],
+  subSectionList: String[],
+  treeStructure: Object[]
+  treeSelected: String | null
+}

--- a/src/types/applicationState.ts
+++ b/src/types/applicationState.ts
@@ -6,11 +6,14 @@ export default interface ApplicationState {
   ageGroupOptions: FacetOption[],
   ageAtOptions: FacetOption[],
   facetFilter: {
-    gender: Strin    ageAtOptions: FacetOption[],    facetFilter: {      gender: String[],        subcohort: String[],      ageGroupAt1A: String[,],s  aeGroupAt2A: String[],	      ageGroupAt3A: String]t,
-      yearOfBirthRange: Number[]
-    }
-  }	  sectionLis
-t: String ,
+    gender: String[],
+    subcohort: String[],
+    ageGroupAt1A: String[],
+    ageGroupAt2A: String[],	      
+    ageGroupAt3A: String[],
+    yearOfBirthRange: Number[]
+  },	  
+  sectionList: String[],
   subSectionList: String[],
   treeStructure: Object[]
   treeSelected: String | null

--- a/src/types/applicationState.ts
+++ b/src/types/applicationState.ts
@@ -1,13 +1,16 @@
-import ToggleFacetOption from '@/types/toggleFacetOption'
+import FacetOption from '@/types/facetOption'
 
 export default interface ApplicationState {
-  genderOptions: ToggleFacetOption[],
-  subcohortOptions: ToggleFacetOption[],
+  genderOptions: FacetOption[],
+  subcohortOptions: FacetOption[],
+  ageGroupOptions: FacetOption[],
+  ageAtOptions: FacetOption[],
   facetFilter: {
-    gender: String[],
-    subcohort: String[]
-  },
-  sectionList: String[],
+    gender: Strin    ageAtOptions: FacetOption[],    facetFilter: {      gender: String[],        subcohort: String[],      ageGroupAt1A: String[,],s  aeGroupAt2A: String[],	      ageGroupAt3A: String]t,
+      yearOfBirthRange: Number[]
+    }
+  }	  sectionLis
+t: String ,
   subSectionList: String[],
   treeStructure: Object[]
   treeSelected: String | null

--- a/src/types/facetOption.ts
+++ b/src/types/facetOption.ts
@@ -1,0 +1,4 @@
+export default interface FacetOption {
+    value: String,
+    text: String
+}

--- a/src/types/toggleFacetOption.ts
+++ b/src/types/toggleFacetOption.ts
@@ -1,4 +1,0 @@
-export default interface ToggleFacetOption {
-    value: String,
-    text: String
-}

--- a/src/views/ContentView.vue
+++ b/src/views/ContentView.vue
@@ -1,13 +1,18 @@
 <template>
   <div id="Content-view">
-    <h3>{{ 'lifelines-webshop-content-header' | i18n }}</h3>
+    <h3>2. Select data</h3>
+    <div class="row">
+      <tree-view class="col-sm-3" />
+    </div>
   </div>
 </template>
 
 <script>
 import Vue from 'vue'
+import TreeView from './TreeView.vue'
 
 export default Vue.extend({
-  name: 'ContentView'
+  name: 'ContentView',
+  components: { TreeView }
 })
 </script>

--- a/src/views/MainView.vue
+++ b/src/views/MainView.vue
@@ -1,7 +1,7 @@
 <template>
   <div id="main-view" class="row">
-    <sidebar-view class="col-sm-3" />
-    <content-view class="col-sm-9" />
+    <sidebar-view class="col-sm-4 col-md-3 col-xl-2" />
+    <content-view class="col-sm-8 col-md-9 col-xl-10"/>
   </div>
 </template>
 

--- a/src/views/SidebarView.vue
+++ b/src/views/SidebarView.vue
@@ -3,10 +3,47 @@
     <h3>{{ 'lifelines-webshop-sidebar-header' | i18n }}</h3>
     <ul class="list-unstyled">
       <li>
-        <toggle-facet facetId="gender" label="Gender" :options="genderOptions" v-model="selectedGenderOptions" />
+        <facet-container
+          facetId="age"
+          label="Age"
+          :collapsable="true"
+          :collapsed="activeAgeFacetId !== 'age'"
+          @facetToggle="handleAgeToggle">
+            <age-facet
+            facetId="age"
+            :ageGroupOptions="ageGroupOptions"
+            :ageAtOptions="ageAtOptions"
+            v-model="selectedAgeAt" />
+        </facet-container>
       </li>
       <li>
-        <toggle-facet facetId="cohort" label="Subcohorts" :options="subcohortOptions" v-model="selectedSubcohortOptions" />
+        <facet-container
+          facetId="yob"
+          label="Year of birth"
+          :collapsable="true"
+          :collapsed="activeAgeFacetId !== 'yob'"
+          @facetToggle="handleAgeToggle">
+            <range-facet
+            facetId="yob"
+            :min="1900" :max="2050"
+            v-model="selectedAgeRange"/>
+        </facet-container>
+      </li>
+      <li>
+        <facet-container facetId="gender" label="Gender">
+          <toggle-facet
+          facetId="gender"
+          :options="genderOptions"
+          v-model="selectedGenderOptions" />
+        </facet-container>
+      </li>
+      <li>
+        <facet-container facetId="cohort" label="Subcohorts">
+          <toggle-facet
+          facetId="cohort"
+          :options="subcohortOptions"
+          v-model="selectedSubcohortOptions" />
+        </facet-container>
       </li>
     </ul>
   </div>
@@ -14,18 +51,60 @@
 
 <script>
 import Vue from 'vue'
+import FacetContainer from '../components/facets/FacetContainer.vue'
 import ToggleFacet from '../components/facets/ToggleFacet.vue'
+import AgeFacet from '../components/facets/AgeFacet.vue'
+import RangeFacet from '../components/facets/RangeFacet.vue'
 import { mapMutations } from 'vuex'
 
 export default Vue.extend({
   name: 'SidebarView',
-  components: { ToggleFacet },
+  components: { FacetContainer, ToggleFacet, AgeFacet, RangeFacet },
+  data: function () {
+    return {
+      activeAgeFacetId: 'age',
+      cachedAgeState: null
+    }
+  },
+  methods: {
+    handleAgeToggle (event) {
+      const { collapsed, facetId } = event
+      if (facetId === 'yob') {
+        this.activeAgeFacetId = collapsed ? 'yob' : 'age'
+      }
+      if (facetId === 'age') {
+        this.activeAgeFacetId = collapsed ? 'age' : 'yob'
+      }
+    }
+  },
+  watch: {
+    activeAgeFacetId (active) {
+      if (active === 'age') {
+        const tempState = [...this.selectedAgeRange]
+        this.$store.commit('removeYearOfBirthRangefilter')
+        this.$store.commit('updateSelectedAgeAt', this.cachedAgeState)
+        this.cachedAgeState = tempState
+      }
+      if (active === 'yob') {
+        const tempState = Object.assign({}, this.selectedAgeAt)
+        this.$store.commit('removeAgeAtFilter')
+        this.$store.commit('updateYearOfBirthRangefilter', this.cachedAgeState)
+        this.cachedAgeState = tempState
+      }
+    }
+  },
   computed: {
     genderOptions () {
       return this.$store.state.genderOptions
     },
     subcohortOptions () {
       return this.$store.state.subcohortOptions
+    },
+    ageGroupOptions () {
+      return this.$store.state.ageGroupOptions
+    },
+    ageAtOptions () {
+      return this.$store.state.ageAtOptions
     },
     selectedGenderOptions: {
       get () {
@@ -42,8 +121,35 @@ export default Vue.extend({
       set (value) {
         this.$store.commit('updateSubcohortfilter', value)
       }
+    },
+    selectedAgeAt: {
+      get () {
+        const filter = this.$store.state.facetFilter
+        return {
+          ageGroupAt1A: filter.ageGroupAt1A,
+          ageGroupAt2A: filter.ageGroupAt2A,
+          ageGroupAt3A: filter.ageGroupAt3A
+        }
+      },
+      set (value) {
+        this.$store.commit('updateSelectedAgeAt', value)
+      }
+    },
+    selectedAgeRange: {
+      get () {
+        return this.$store.state.facetFilter.yearOfBirthRange
+      },
+      set (value) {
+        this.$store.commit('updateYearOfBirthRangefilter', value)
+      }
     }
 
   }
 })
 </script>
+
+<style>
+.facet {
+  margin-top: 0.5rem;
+}
+</style>

--- a/src/views/TreeView.vue
+++ b/src/views/TreeView.vue
@@ -1,0 +1,31 @@
+<template>
+  <div id="tree-view">
+    <collapsible-tree v-model="selection" :structure="structure" />
+  </div>
+</template>
+
+<script>
+import Vue from 'vue'
+import CollapsibleTree from '../components/tree/CollapsibleTree.vue'
+
+export default Vue.extend({
+  name: 'TreeView',
+  computed: {
+    structure () {
+      return this.$store.state.treeStructure
+    },
+    selection: {
+      get () {
+        return this.$store.state.treeSelected
+      },
+      set (value) {
+        this.$store.commit('updateTreeSelection', value)
+      }
+    }
+  },
+  created () {
+    this.$store.dispatch('loadTreeStructure')
+  },
+  components: { CollapsibleTree }
+})
+</script>

--- a/tests/e2e/specs/MainView.js
+++ b/tests/e2e/specs/MainView.js
@@ -6,8 +6,8 @@ module.exports = {
     browser
       .url(process.env.VUE_DEV_SERVER_URL)
       .waitForElementVisible('#main-view', 5000)
-      .assert.elementPresent('div.row > .col-sm-3')
-      .assert.elementPresent('div.row > .col-sm-9')
+      .assert.elementPresent('div.row > .col-sm-4')
+      .assert.elementPresent('div.row > .col-sm-8')
       .end()
   }
 }

--- a/tests/unit/components/animations/TransitionExpand.spec.ts
+++ b/tests/unit/components/animations/TransitionExpand.spec.ts
@@ -1,0 +1,35 @@
+import { shallowMount, Wrapper, TransitionStub } from '@vue/test-utils'
+import Vue from 'vue'
+import TransitionExpand from '@/components/animations/TransitionExpand.vue'
+
+describe('TransitionExpand.vue', () => {
+  let wrapper: Wrapper<Vue>
+
+  beforeEach(() => {
+    wrapper = shallowMount(TransitionExpand, {
+      stubs: {
+        transition: TransitionStub
+      },
+      slots: { default: '<div><div id="test">test</div></div>' }
+    })
+  })
+
+  it('It animates the element', (done) => {
+    const test = wrapper.find('#test')
+
+    // @ts-ignore
+    wrapper.vm.enter(test.element)
+    expect(test.element.style.height).toBe('0px')
+
+    // @ts-ignore
+    wrapper.vm.afterEnter(test.element)
+    expect(test.element.style.height).toBe('auto')
+
+    // @ts-ignore
+    wrapper.vm.leave(test.element)
+    setTimeout(() => {
+      expect(test.element.style.height).toBe('0px')
+      done()
+    }, 100)
+  })
+})

--- a/tests/unit/components/facets/AgeFacet.spec.ts
+++ b/tests/unit/components/facets/AgeFacet.spec.ts
@@ -1,0 +1,88 @@
+import { shallowMount, Wrapper } from '@vue/test-utils'
+import Vue from 'vue'
+import AgeFacet from '@/components/facets/AgeFacet.vue'
+
+describe('AgeFacet.vue', () => {
+  const ageAtOptions = [
+    { value: 'ageGroupAt1A', text: 'baseline' },
+    { value: 'ageGroupAt2A', text: 'second assessment' },
+    { value: 'ageGroupAt3A', text: 'third assessment' }
+  ]
+  const ageGroupOptions = [
+    { value: '1', text: '0-17' },
+    { value: '2', text: '18-65' },
+    { value: '3', text: '65+' }
+  ]
+  const basicProps = {
+    facetId: 'my-age-facet',
+    label: 'age facet label',
+    ageAtOptions,
+    ageGroupOptions,
+    value: {}
+  }
+
+  describe('data', () => {
+    let wrapper: Wrapper<Vue>
+
+    beforeEach(() => {
+      wrapper = shallowMount(AgeFacet, { propsData: basicProps })
+    })
+
+    it('selectedAgeGroups should be empty array if none are passed', () => {
+      // @ts-ignore
+      expect(wrapper.vm.selectedAgeGroups).toEqual([])
+    })
+
+    it('selectedAgeAt default to "ageGroupAt1A"', () => {
+      // @ts-ignore
+      expect(wrapper.vm.selectedAgeAt).toEqual('ageGroupAt1A')
+    })
+  })
+
+  describe('change selected age groups', () => {
+    let wrapper: Wrapper<Vue>
+
+    beforeEach(() => {
+      wrapper = shallowMount(AgeFacet, { propsData: basicProps })
+    })
+
+    it('should result in input event with updated selectedAgeAt object ', () => {
+      const expectedPayload = {
+        ageGroupAt1A: ['0-17'],
+        ageGroupAt2A: [],
+        ageGroupAt3A: []
+      }
+      wrapper.setData({ selectedAgeGroups: ['0-17'] })
+      expect(wrapper.emitted().input[0][0]).toEqual(expectedPayload)
+    })
+  })
+
+  describe('select age-at', () => {
+    let wrapper: Wrapper<Vue>
+
+    beforeEach(() => {
+      const myProps = {
+        facetId: 'my-age-facet',
+        label: 'age facet label',
+        ageAtOptions,
+        ageGroupOptions,
+        value: {
+          ageGroupAt1A: ['0-17'],
+          ageGroupAt2A: [],
+          ageGroupAt3A: []
+        }
+      }
+      wrapper = shallowMount(AgeFacet, { propsData: myProps })
+    })
+
+    it('should result in input event with updated selectedAgeAt object ', () => {
+      const expectedPayload = {
+        ageGroupAt1A: [],
+        ageGroupAt2A: ['0-17'],
+        ageGroupAt3A: []
+      }
+      wrapper.setData({ selectedAgeAt: 'ageGroupAt2A' })
+      expect(wrapper.emitted().input[0][0]).toEqual(expectedPayload)
+    })
+  })
+})

--- a/tests/unit/components/facets/FacetContainer.spec.ts
+++ b/tests/unit/components/facets/FacetContainer.spec.ts
@@ -1,0 +1,37 @@
+import { shallowMount, Wrapper } from '@vue/test-utils'
+import Vue from 'vue'
+import FacetContainer from '@/components/facets/FacetContainer.vue'
+
+describe('FacetContainer.vue', () => {
+  describe('handleFacetToggle', () => {
+    it('should emit the facetToggle passing on the current state', () => {
+      let wrapper = shallowMount(FacetContainer, {
+        stubs: ['font-awesome-icon'],
+        propsData: {
+          facetId: 'my-facet',
+          label: 'label yo',
+          collapsable: true,
+          collapsed: false
+        }
+      })
+      // @ts-ignore
+      wrapper.vm.handleFacetToggle()
+      expect(wrapper.emitted().facetToggle[0][0]).toEqual({ facetId: 'my-facet', collapsed: false })
+    })
+
+    it('should short cicuit if not collapsable', () => {
+      let wrapper = shallowMount(FacetContainer, {
+        stubs: ['font-awesome-icon'],
+        propsData: {
+          facetId: 'my-facet',
+          label: 'label yo',
+          collapsable: false,
+          collapsed: false
+        }
+      })
+      // @ts-ignore
+      wrapper.vm.handleFacetToggle()
+      expect(wrapper.emitted()).toEqual({})
+    })
+  })
+})

--- a/tests/unit/components/facets/RangeFacet.spec.ts
+++ b/tests/unit/components/facets/RangeFacet.spec.ts
@@ -1,0 +1,92 @@
+import { shallowMount, Wrapper } from '@vue/test-utils'
+import Vue from 'vue'
+import RangeFacet from '@/components/facets/RangeFacet.vue'
+
+describe('RangeFacet.vue', () => {
+  const minimalProps = {
+    facetId: 'my-range-facet',
+    label: 'my range facet label'
+  }
+
+  describe('initializeSlider', () => {
+    it('should initialize the range if none is passed', () => {
+      let wrapper = shallowMount(RangeFacet, { propsData: minimalProps })
+      // @ts-ignore
+      expect(wrapper.vm.sliderValue).toEqual([1900, 2050])
+    })
+
+    it('should used the passed range if set', () => {
+      const propsData = {
+        facetId: 'my-range-facet',
+        label: 'my range facet label',
+        value: [1990, 2010]
+      }
+      let wrapper = shallowMount(RangeFacet, { propsData })
+      // @ts-ignore
+      expect(wrapper.vm.sliderValue).toEqual([1990, 2010])
+    })
+
+    it('should use the default if empty range is passed', () => {
+      const propsData = {
+        facetId: 'my-range-facet',
+        label: 'my range facet label',
+        value: []
+      }
+      let wrapper = shallowMount(RangeFacet, { propsData })
+      // @ts-ignore
+      expect(wrapper.vm.sliderValue).toEqual([1900, 2050])
+    })
+  })
+
+  describe('handleSliderChange', () => {
+    let wrapper: Wrapper<Vue>
+
+    beforeEach(() => {
+      wrapper = shallowMount(RangeFacet, { propsData: minimalProps })
+    })
+
+    it('should emit a input event passing a clone of the new data', () => {
+      // @ts-ignore
+      wrapper.vm.handleSliderChange(['1980', '2019'])
+      expect(wrapper.emitted().input[0][0]).toEqual([1980, 2019])
+    })
+  })
+
+  describe('handleFromChange', () => {
+    let wrapper: Wrapper<Vue>
+
+    beforeEach(() => {
+      wrapper = shallowMount(RangeFacet, { propsData: minimalProps })
+    })
+
+    it('should update the from value and emit the new range', () => {
+      const event = {
+        currentTarget: {
+          value: '2011'
+        }
+      }
+      // @ts-ignore
+      wrapper.vm.handleFromChange(event)
+      expect(wrapper.emitted().input[0][0]).toEqual([2011, 2050])
+    })
+  })
+
+  describe('handleUntilChange', () => {
+    let wrapper: Wrapper<Vue>
+
+    beforeEach(() => {
+      wrapper = shallowMount(RangeFacet, { propsData: minimalProps })
+    })
+
+    it('should update the until value and emit the new range', () => {
+      const event = {
+        currentTarget: {
+          value: '2019'
+        }
+      }
+      // @ts-ignore
+      wrapper.vm.handleUntilChange(event)
+      expect(wrapper.emitted().input[0][0]).toEqual([1900, 2019])
+    })
+  })
+})

--- a/tests/unit/components/tree/CollapsibleTree.spec.ts
+++ b/tests/unit/components/tree/CollapsibleTree.spec.ts
@@ -1,0 +1,50 @@
+import { mount, Wrapper } from '@vue/test-utils'
+import Vue from 'vue'
+import CollapsibleTree from '@/components/tree/CollapsibleTree.vue'
+
+describe('CollapsibleTree.vue', () => {
+  let wrapper: Wrapper<Vue>
+
+  beforeEach(() => {
+    wrapper = mount(CollapsibleTree, {
+      stubs: {
+        'font-awesome-icon': '<div/>'
+      },
+      propsData: {
+        value: '',
+        structure: [
+          {
+            name: 'test-parent',
+            open: true,
+            children: [
+              {
+                name: 'test-child'
+              }
+            ]
+          }
+        ]
+      }
+    })
+  })
+
+  it('should render a list with a test-parent and test-child', () => {
+    const items = wrapper.findAll('[title]')
+    expect(items.length).toEqual(2)
+    expect(items.at(0).text()).toEqual('test-parent')
+    expect(items.at(1).text()).toEqual('test-child')
+  })
+
+  it('can close and hide children', () => {
+    wrapper.find('[title="test-parent"]').trigger('click')
+    let items = wrapper.findAll('[title]')
+    expect(items.length).toEqual(1)
+    wrapper.find('[title="test-parent"]').trigger('click')
+    items = wrapper.findAll('[title]')
+    expect(items.length).toEqual(2)
+  })
+
+  it('can can select child', () => {
+    wrapper.find('[title="test-child"]').trigger('click')
+    expect(wrapper.emitted().input[0]).toEqual(['test-child'])
+  })
+})

--- a/tests/unit/views/SidebarView.spec.ts
+++ b/tests/unit/views/SidebarView.spec.ts
@@ -18,9 +18,15 @@ describe('SidebarView.vue', () => {
     state = {
       genderOptions: [{ value: '1', text: 'Male' }],
       subcohortOptions: [{ value: '101', text: 'baseline' }],
+      ageGroupOptions: [],
+      ageAtOptions: [],
       facetFilter: {
         gender: [],
-        subcohort: []
+        subcohort: [],
+        ageGroupAt1A: [],
+        ageGroupAt2A: [],
+        ageGroupAt3A: [],
+        yearOfBirthRange: []
       },
       treeStructure: [],
       sectionList: [],
@@ -58,5 +64,81 @@ describe('SidebarView.vue', () => {
     // @ts-ignore
     wrapper.vm.selectedSubcohortOptions = ['123']
     expect(commitMock).toBeCalledWith('updateSubcohortfilter', ['123'])
+  })
+
+  it('should commit the new selectedAgeAt filter to the store when updated', () => {
+    // @ts-ignore
+    wrapper.vm.selectedAgeAt = {
+      ageGroupAt1A: [],
+      ageGroupAt2A: [],
+      ageGroupAt3A: ['0-17', '65+']
+    }
+    expect(commitMock).toBeCalledWith('updateSelectedAgeAt', {
+      ageGroupAt1A: [],
+      ageGroupAt2A: [],
+      ageGroupAt3A: ['0-17', '65+']
+    })
+  })
+
+  it('should commit the new selectedAgeRange filter to the store when updated', () => {
+    // @ts-ignore
+    wrapper.vm.selectedAgeRange = [2000, 2011]
+    expect(commitMock).toBeCalledWith('updateYearOfBirthRangefilter', [2000, 2011])
+  })
+
+  it('should cache the current age data, clear the age data in the store and activate the new age filter, initilizing it with the cached data', () => {
+    wrapper.setData({ activeAgeFacetId: 'yob' })
+    expect(commitMock).toBeCalledWith('removeAgeAtFilter')
+
+    wrapper.setData({ activeAgeFacetId: 'age' })
+    expect(commitMock).toBeCalledWith('removeYearOfBirthRangefilter')
+  })
+
+  describe('handleAgeToggle', () => {
+    describe('when toggeling the yob facet when it is collapsed', () => {
+      beforeEach(() => {
+        // @ts-ignore
+        wrapper.vm.handleAgeToggle({ collapsed: true, facetId: 'yob' })
+      })
+      it('yob should become the active facet', () => {
+        // @ts-ignore
+        expect(wrapper.vm.activeAgeFacetId).toBe('yob')
+  
+      })
+    })
+    describe('when toggeling the yob facet when it is open', () => {
+      beforeEach(() => {
+        // @ts-ignore
+        wrapper.vm.handleAgeToggle({ collapsed: false, facetId: 'yob' })
+      })
+      it('age should become the facet', () => {
+        // @ts-ignore
+        expect(wrapper.vm.activeAgeFacetId).toBe('age')
+  
+      })
+    })
+    describe('when toggeling the age facet when it is collapsed', () => {
+      beforeEach(() => {
+        // @ts-ignore
+        wrapper.vm.handleAgeToggle({ collapsed: true, facetId: 'age' })
+      })
+      it('age should become the active facet', () => {
+        // @ts-ignore
+        expect(wrapper.vm.activeAgeFacetId).toBe('age')
+  
+      })
+    })
+    describe('when toggeling the age facet when it is open', () => {
+      beforeEach(() => {
+        // @ts-ignore
+        wrapper.vm.handleAgeToggle({ collapsed: false, facetId: 'age' })
+      })
+      it('yob should become the facet', () => {
+        // @ts-ignore
+        expect(wrapper.vm.activeAgeFacetId).toBe('yob')
+  
+      })
+    })
+    
   })
 })

--- a/tests/unit/views/SidebarView.spec.ts
+++ b/tests/unit/views/SidebarView.spec.ts
@@ -21,7 +21,11 @@ describe('SidebarView.vue', () => {
       facetFilter: {
         gender: [],
         subcohort: []
-      }
+      },
+      treeStructure: [],
+      sectionList: [],
+      subSectionList: [],
+      treeSelected: ''
     }
 
     wrapper = shallowMount(SidebarView, {

--- a/tests/unit/views/TreeView.spec.ts
+++ b/tests/unit/views/TreeView.spec.ts
@@ -1,0 +1,59 @@
+import { mount, createLocalVue, Wrapper } from '@vue/test-utils'
+import TreeView from '@/views/TreeView.vue'
+import Vue from 'vue'
+import Vuex from 'vuex'
+import ApplicationState from '@/types/ApplicationState'
+
+const localVue = createLocalVue()
+localVue.use(Vuex)
+
+Vue.filter('i18n', (value: string) => value) // Add dummy filter for i18n
+
+describe('TreeView.vue', () => {
+  let wrapper: Wrapper<Vue>
+  let state: ApplicationState
+  let commitMock = jest.fn()
+
+  beforeEach(() => {
+    state = {
+      genderOptions: [{ value: '1', text: 'Male' }],
+      subcohortOptions: [{ value: '101', text: 'baseline' }],
+      facetFilter: {
+        gender: [],
+        subcohort: []
+      },
+      treeStructure: [{
+        name: 'parent',
+        open: true,
+        children: [
+          {
+            name: 'child'
+          }
+        ]
+      }],
+      sectionList: [],
+      subSectionList: [],
+      treeSelected: ''
+    }
+
+    wrapper = mount(TreeView, {
+      stubs: {
+        'font-awesome-icon': '<div/>'
+      },
+      mocks: {
+        $store: {
+          state,
+          commit: commitMock,
+          dispatch: jest.fn()
+        }
+      },
+      localVue
+    })
+  })
+
+  it('Can select child item', () => {
+    expect(wrapper.exists()).toBeTruthy()
+    wrapper.find('[title="child"]').trigger('click')
+    expect(commitMock.mock.calls).toEqual([ [ 'updateTreeSelection', 'child' ] ])
+  })
+})

--- a/tests/unit/views/TreeView.spec.ts
+++ b/tests/unit/views/TreeView.spec.ts
@@ -18,9 +18,15 @@ describe('TreeView.vue', () => {
     state = {
       genderOptions: [{ value: '1', text: 'Male' }],
       subcohortOptions: [{ value: '101', text: 'baseline' }],
+      ageGroupOptions: [],
+      ageAtOptions: [],
       facetFilter: {
         gender: [],
-        subcohort: []
+        subcohort: [],
+        ageGroupAt1A: [],
+        ageGroupAt2A: [],	      
+        ageGroupAt3A: [],
+        yearOfBirthRange: []
       },
       treeStructure: [{
         name: 'parent',

--- a/vue.config.js
+++ b/vue.config.js
@@ -9,7 +9,7 @@ module.exports = {
     host: process.env.JENKINS_AGENT_NAME || 'localhost',
     proxy: process.env.NODE_ENV === 'production' ? undefined : {
       '^/api': {
-        'target': 'http://localhost:8080'
+        'target': 'https://lifelines.dev.molgenis.org'
       }
     },
     before: function (app, server) {

--- a/yarn.lock
+++ b/yarn.lock
@@ -667,6 +667,30 @@
     lodash "^4.17.11"
     to-fast-properties "^2.0.0"
 
+"@fortawesome/fontawesome-common-types@^0.2.18":
+  version "0.2.18"
+  resolved "https://registry.yarnpkg.com/@fortawesome/fontawesome-common-types/-/fontawesome-common-types-0.2.18.tgz#c0d8f073a5116b2de0a2c8a7aba66093a6956ce7"
+  integrity sha512-834DrzO2Ne3upCW+mJJPC/E6BsFcj+2Z1HmPIhbpbj8UaKmXWum4NClqLpUiMetugRlHuG4jbIHNdv2/lc3c1Q==
+
+"@fortawesome/fontawesome-svg-core@^1.2.18":
+  version "1.2.18"
+  resolved "https://registry.yarnpkg.com/@fortawesome/fontawesome-svg-core/-/fontawesome-svg-core-1.2.18.tgz#c26cbded461895ebe260f0dea771ca29d8cb3517"
+  integrity sha512-1vyLWVQqxQ8q8bA2zgZcljk3RkeELlDJ757ymLk+ebK019AFgEFH5kTnR5OMN1SFsTwW1OHlFQO3VufdeCg/Gg==
+  dependencies:
+    "@fortawesome/fontawesome-common-types" "^0.2.18"
+
+"@fortawesome/free-solid-svg-icons@^5.8.2":
+  version "5.8.2"
+  resolved "https://registry.yarnpkg.com/@fortawesome/free-solid-svg-icons/-/free-solid-svg-icons-5.8.2.tgz#aa2f042f73aca43eb4a26149907e63bf26d2e31c"
+  integrity sha512-5tF6WOFlqqO95zY5ukSB6jliDa3jnk1p5L4K/a58ccDFsbjSkhfGuvZkRkeWxH8uMms81pZd6yQTwQrkedeJmg==
+  dependencies:
+    "@fortawesome/fontawesome-common-types" "^0.2.18"
+
+"@fortawesome/vue-fontawesome@^0.1.6":
+  version "0.1.6"
+  resolved "https://registry.yarnpkg.com/@fortawesome/vue-fontawesome/-/vue-fontawesome-0.1.6.tgz#18a0f4263b90f65180fc927325ba01896276ea04"
+  integrity sha512-HAGRbrOuGDwwUmCYdpzR0hhNQ3EE30dOS4JiJKcoZ+S4M210CxyU0OXCgzIg3HzK/23rlpHbV8zi9PDDZDnuIw==
+
 "@intervolga/optimize-cssnano-plugin@^1.0.5":
   version "1.0.6"
   resolved "https://registry.yarnpkg.com/@intervolga/optimize-cssnano-plugin/-/optimize-cssnano-plugin-1.0.6.tgz#be7c7846128b88f6a9b1d1261a0ad06eb5c0fdf8"

--- a/yarn.lock
+++ b/yarn.lock
@@ -667,24 +667,24 @@
     lodash "^4.17.11"
     to-fast-properties "^2.0.0"
 
-"@fortawesome/fontawesome-common-types@^0.2.18":
-  version "0.2.18"
-  resolved "https://registry.yarnpkg.com/@fortawesome/fontawesome-common-types/-/fontawesome-common-types-0.2.18.tgz#c0d8f073a5116b2de0a2c8a7aba66093a6956ce7"
-  integrity sha512-834DrzO2Ne3upCW+mJJPC/E6BsFcj+2Z1HmPIhbpbj8UaKmXWum4NClqLpUiMetugRlHuG4jbIHNdv2/lc3c1Q==
+"@fortawesome/fontawesome-common-types@^0.2.19":
+  version "0.2.19"
+  resolved "https://registry.yarnpkg.com/@fortawesome/fontawesome-common-types/-/fontawesome-common-types-0.2.19.tgz#754a0f85e1290858152e1c05700ab502b11197f1"
+  integrity sha512-nd2Ul/CUs8U9sjofQYAALzOGpgkVJQgEhIJnOHaoyVR/LeC3x2mVg4eB910a4kS6WgLPebAY0M2fApEI497raQ==
 
-"@fortawesome/fontawesome-svg-core@^1.2.18":
-  version "1.2.18"
-  resolved "https://registry.yarnpkg.com/@fortawesome/fontawesome-svg-core/-/fontawesome-svg-core-1.2.18.tgz#c26cbded461895ebe260f0dea771ca29d8cb3517"
-  integrity sha512-1vyLWVQqxQ8q8bA2zgZcljk3RkeELlDJ757ymLk+ebK019AFgEFH5kTnR5OMN1SFsTwW1OHlFQO3VufdeCg/Gg==
+"@fortawesome/fontawesome-svg-core@^1.2.19":
+  version "1.2.19"
+  resolved "https://registry.yarnpkg.com/@fortawesome/fontawesome-svg-core/-/fontawesome-svg-core-1.2.19.tgz#0eca1ce9285c3d99e6e340633ee8f615f9d1a2e0"
+  integrity sha512-D4ICXg9oU08eF9o7Or392gPpjmwwgJu8ecCFusthbID95CLVXOgIyd4mOKD9Nud5Ckz+Ty59pqkNtThDKR0erA==
   dependencies:
-    "@fortawesome/fontawesome-common-types" "^0.2.18"
+    "@fortawesome/fontawesome-common-types" "^0.2.19"
 
-"@fortawesome/free-solid-svg-icons@^5.8.2":
-  version "5.8.2"
-  resolved "https://registry.yarnpkg.com/@fortawesome/free-solid-svg-icons/-/free-solid-svg-icons-5.8.2.tgz#aa2f042f73aca43eb4a26149907e63bf26d2e31c"
-  integrity sha512-5tF6WOFlqqO95zY5ukSB6jliDa3jnk1p5L4K/a58ccDFsbjSkhfGuvZkRkeWxH8uMms81pZd6yQTwQrkedeJmg==
+"@fortawesome/free-solid-svg-icons@^5.9.0":
+  version "5.9.0"
+  resolved "https://registry.yarnpkg.com/@fortawesome/free-solid-svg-icons/-/free-solid-svg-icons-5.9.0.tgz#1c73e7bac17417d23f934d83f7fff5b100a7fda9"
+  integrity sha512-U8YXPfWcSozsCW0psCtlRGKjjRs5+Am5JJwLOUmVHFZbIEWzaz4YbP84EoPwUsVmSAKrisu3QeNcVOtmGml0Xw==
   dependencies:
-    "@fortawesome/fontawesome-common-types" "^0.2.18"
+    "@fortawesome/fontawesome-common-types" "^0.2.19"
 
 "@fortawesome/vue-fontawesome@^0.1.6":
   version "0.1.6"
@@ -10406,6 +10406,11 @@ vm-browserify@0.0.4:
   dependencies:
     indexof "0.0.1"
 
+vue-class-component@^7.0.1:
+  version "7.1.0"
+  resolved "https://registry.yarnpkg.com/vue-class-component/-/vue-class-component-7.1.0.tgz#b33efcb10e17236d684f70b1e96f1946ec793e87"
+  integrity sha512-G9152NzUkz0i0xTfhk0Afc8vzdXxDR1pfN4dTwE72cskkgJtdXfrKBkMfGvDuxUh35U500g5Ve4xL8PEGdWeHg==
+
 vue-eslint-parser@^2.0.3:
   version "2.0.3"
   resolved "https://registry.yarnpkg.com/vue-eslint-parser/-/vue-eslint-parser-2.0.3.tgz#c268c96c6d94cfe3d938a5f7593959b0ca3360d1"
@@ -10462,10 +10467,25 @@ vue-loader@^15.7.0:
     vue-hot-reload-api "^2.3.0"
     vue-style-loader "^4.1.0"
 
+vue-property-decorator@^8.0.0:
+  version "8.2.1"
+  resolved "https://registry.yarnpkg.com/vue-property-decorator/-/vue-property-decorator-8.2.1.tgz#3791662033b20d20d098cb20e86fd23842982508"
+  integrity sha512-zgtcvzGB2JpDqnIxVhTK+6m+dv3uyhYs+tL8elL+DWiXj9kDonKcPY7f1DHYX1NlnWPCj7ht0nL/i8+S1gg76Q==
+  dependencies:
+    vue "^2.6.10"
+    vue-class-component "^7.0.1"
+
 vue-router@^3.0.3:
   version "3.0.6"
   resolved "https://registry.yarnpkg.com/vue-router/-/vue-router-3.0.6.tgz#2e4f0f9cbb0b96d0205ab2690cfe588935136ac3"
   integrity sha512-Ox0ciFLswtSGRTHYhGvx2L44sVbTPNS+uD2kRISuo8B39Y79rOo0Kw0hzupTmiVtftQYCZl87mwldhh2L9Aquw==
+
+vue-slider-component@^3.0.32:
+  version "3.0.32"
+  resolved "https://registry.yarnpkg.com/vue-slider-component/-/vue-slider-component-3.0.32.tgz#bc241280cd7371c24eb749c28088e2365e529aca"
+  integrity sha512-uF8R6fqUPzqMTbzyujppG2oGl+n2rvG8k5KTVBBSJqDh4dC+WqxtjFb9oQlTmUVBOmlEwC2MFYYQfXmZ5OeftA==
+  dependencies:
+    vue-property-decorator "^8.0.0"
 
 vue-style-loader@^4.1.0:
   version "4.1.2"


### PR DESCRIPTION
Add ‘complex’ age facet

- User can should between filtering age as age group(s) at assessment time
 for example ‘0-17 at baseline’ or filtering age by year of birth range(yob)
- Add range facet to facilitate year of birth range selection
- Add combination facet ( toggle facet + age-ate selector)
- Wrap all facets in collapsable container  ( either age-group or yob is active at one time)
- Add font awesome lib for chevrons  
- Link all facets to the store and keep store is format needed for request
- Add/ Extent unit tests for all facets 

#### Checklist
- [ ] Functionality works & meets specifications
- [ ] Code reviewed
- [ ] Code unit/integration/system tested
- [ ] User documentation updated
- [ ] Conventional commits (squash if needed)
- [ ] No warnings during install
- [ ] Updated javascript typing
