### PR TITLE
fix(age-facet): init age facet component cache with empty array for y…

### DIFF
--- a/src/views/SidebarView.vue
+++ b/src/views/SidebarView.vue
@@ -63,7 +63,7 @@ export default Vue.extend({
   data: function () {
     return {
       activeAgeFacetId: 'age',
-      cachedAgeState: null
+      cachedAgeState: []
     }
   },
   methods: {


### PR DESCRIPTION
…ob instead of null

#### Checklist
- [x] Functionality works & meets specifications
- [x] Code reviewed
- [x] Code unit/integration/system tested
- [x] User documentation updated
- [x] Conventional commits (squash if needed)
- [x] No warnings during install
- [x] Updated javascript typing
