### PR TITLE
feat: load and save orders in the agreed upon format

### DIFF
--- a/src/App.vue
+++ b/src/App.vue
@@ -4,19 +4,6 @@
   </div>
 </template>
 
-<script lang="ts">
-import Vue from 'vue'
-import { mapActions } from 'vuex'
-export default Vue.extend({
-  methods: {
-    ...mapActions(['loadVariables'])
-  },
-  created () {
-    this.loadVariables()
-  }
-})
-</script>
-
 <style lang="scss">
   @import "scss/bootstrap-lifelines-webshop.scss";
 </style>

--- a/src/components/grid/GridComponent.vue
+++ b/src/components/grid/GridComponent.vue
@@ -109,7 +109,7 @@ export default Vue.extend({
       })
     },
     ...mapMutations(['toggleGridSelection', 'toggleGridRow', 'toggleGridColumn', 'toggleAll']),
-    ...mapActions(['loadGridVariables', 'loadAssessments', 'loadGridData'])
+    ...mapActions(['loadGridVariables', 'loadGridData'])
   },
   computed: {
     ...mapState(['treeSelected', 'gridVariables', 'assessments', 'variantCounts']),
@@ -130,7 +130,6 @@ export default Vue.extend({
     }
   },
   created () {
-    this.loadAssessments()
     this.loadGridData()
   }
 })

--- a/src/router.ts
+++ b/src/router.ts
@@ -12,6 +12,11 @@ export default new Router({
       path: '/',
       name: 'home',
       component: MainView
+    },
+    {
+      path: '/:cartId',
+      name: 'load',
+      component: MainView
     }
   ]
 })

--- a/src/store/actions.ts
+++ b/src/store/actions.ts
@@ -5,6 +5,7 @@ import { Variable } from '@/types/Variable'
 import Assessment from '@/types/Assessment'
 import { Cart } from '@/types/Cart'
 import ApplicationState from '@/types/ApplicationState'
+import router from '@/router'
 
 export default {
   loadSections: tryAction(async ({ commit, state } : any) => {
@@ -94,17 +95,20 @@ export default {
       commit('updateVariantCounts', variantCounts)
     }
   }),
-  save: tryAction(async ({ state }: {state: ApplicationState}) => {
+  save: tryAction(async ({ state, commit }: {state: ApplicationState, commit: any}) => {
     const body = { contents: JSON.stringify(toCart(state)) }
     const response = await api.post('/api/v1/lifelines_cart', { body: JSON.stringify(body) })
     const location: string = response.headers.get('Location')
     const id: string = location.substring(location.lastIndexOf('/') + 1)
+    commit('setToast', { type: 'success', message: 'Saved order with id ' + id })
+    router.push({name: 'load', params: {cartId: id}})
   }),
-  load: tryAction(async ({ state, commit }:{state: ApplicationState, commit: any}, id: string) => {
+  load: tryAction(async ({ state, commit }: {state: ApplicationState, commit: any}, id: string) => {
     const response = await api.get(`/api/v2/lifelines_cart/${id}`)
     const cart: Cart = JSON.parse(response.contents)
     const { facetFilter, gridSelection } = fromCart(cart, state)
     commit('updateFacetFilter', facetFilter)
     commit('updateGridSelection', gridSelection)
+    commit('setToast', { type: 'success', message: 'Loaded order with id ' + id })
   })
 }

--- a/src/store/helpers.ts
+++ b/src/store/helpers.ts
@@ -1,3 +1,10 @@
+import Assessment from '@/types/Assessment'
+import ApplicationState from '@/types/ApplicationState'
+import { Cart, Selection } from '@/types/Cart'
+import GridSelection from '@/types/GridSelection'
+import Filter from '@/types/Filter'
+import { Variable } from '@/types/Variable'
+
 export const getErrorMessage = (response: any) =>
   response.errors
     ? response.errors[0].code
@@ -13,3 +20,44 @@ export const tryAction = (action: any): any =>
   (context: any, payload: any) =>
     action(context, payload).catch(
       (error: any) => context.commit('setToast', { message: getErrorMessage(error), type: 'danger' }))
+
+export const toCart = ({ gridSelection, facetFilter, assessments, variables }: ApplicationState) : Cart => {
+  const selections: Selection[] = []
+  Object.keys(gridSelection).forEach((variableKey: string) => {
+    const variableId: number = parseInt(variableKey, 10)
+    const variableName: string = variables[variableId].name
+    const assessmentNames: string[] = gridSelection[variableId].map(assessmentId => assessments[assessmentId].name)
+    assessmentNames.forEach(assessmentName => {
+      let selection = selections.find(it => it.assessment === assessmentName)
+      if (selection === undefined) {
+        selection = { assessment: assessmentName, variables: [] }
+        selections.push(selection)
+      }
+      selection.variables.push(variableName)
+    })
+  })
+  return { selection: selections, filters: facetFilter }
+}
+
+export const fromCart = (cart: Cart, { assessments, variables }: ApplicationState) : {facetFilter: Filter, gridSelection: GridSelection} => {
+  const gridSelection: GridSelection = {}
+  cart.selection.forEach((selection: Selection) => {
+    const assessment: Assessment | undefined = Object.values(assessments).find(it => it.name === selection.assessment)
+    if (assessment === undefined) {
+      throw new Error(`Cannot find assessment with name ${selection.assessment}.`)
+    }
+    const assessmentId = assessment.id
+    selection.variables.forEach(variableName => {
+      const variable: Variable | undefined = Object.values(variables).find(it => it.name === variableName)
+      if (variable === undefined) {
+        throw new Error(`Cannot find variable with name ${variableName}.`)
+      }
+      const variableId: number = variable.id
+      if (!gridSelection.hasOwnProperty(variableId)) {
+        gridSelection[variableId] = []
+      }
+      gridSelection[variableId].push(assessmentId)
+    })
+  })
+  return { facetFilter: cart.filters, gridSelection }
+}

--- a/src/store/mutations.ts
+++ b/src/store/mutations.ts
@@ -4,6 +4,7 @@ import Assessment from '@/types/Assessment'
 import Count from '@/types/Count'
 import Vue from 'vue'
 import GridSelection from '@/types/GridSelection'
+import Filter from '@/types/Filter'
 
 export default {
   setToast (state: ApplicationState, toast: Toast) {
@@ -11,6 +12,9 @@ export default {
   },
   clearToast (state: ApplicationState) {
     state.toast = null
+  },
+  updateFacetFilter (state: ApplicationState, facetFilter: Filter) {
+    state.facetFilter = facetFilter
   },
   updateGenderFilter (state: ApplicationState, selectedGenders: string[]) {
     state.facetFilter.gender = selectedGenders

--- a/src/types/ApplicationState.ts
+++ b/src/types/ApplicationState.ts
@@ -3,6 +3,7 @@ import { Variable, VariableWithVariants } from '@/types/Variable'
 import Count from '@/types/Count'
 import Assessment from '@/types/Assessment'
 import GridSelection from '@/types/GridSelection'
+import Filter from './Filter'
 
 export type Toast = {
   type: 'danger' | 'success',
@@ -15,14 +16,7 @@ export default interface ApplicationState {
   subcohortOptions: FacetOption[],
   ageGroupOptions: FacetOption[],
   ageAtOptions: FacetOption[],
-  facetFilter: {
-    gender: string[],
-    subcohort: string[],
-    ageGroupAt1A: string[],
-    ageGroupAt2A: string[],
-    ageGroupAt3A: string[],
-    yearOfBirthRange: number[]
-  },
+  facetFilter: Filter,
   sectionList: string[],
   subSectionList: string[],
   treeStructure: Object[]

--- a/src/types/Cart.ts
+++ b/src/types/Cart.ts
@@ -1,0 +1,11 @@
+import Filter from './Filter'
+
+export interface Cart {
+    selection: Selection[]
+    filters: Filter
+}
+
+export interface Selection {
+    assessment: string
+    variables: string[]
+}

--- a/src/types/Filter.ts
+++ b/src/types/Filter.ts
@@ -1,0 +1,8 @@
+export default interface Filter {
+    gender: string[],
+    subcohort: string[],
+    ageGroupAt1A: string[],
+    ageGroupAt2A: string[],
+    ageGroupAt3A: string[],
+    yearOfBirthRange: number[]
+}

--- a/src/views/MainView.vue
+++ b/src/views/MainView.vue
@@ -1,10 +1,10 @@
 <template>
   <div id="main-view">
-    <div class="pt-3">
-      <img src="logo.svg" alt="Lifelines" />
-    </div>
-    <div class="row justify-content-md-center pt-3">
-        <div class="col-6">
+    <div class="row pt-3">
+      <div class="col col-4">
+        <img src="logo.svg" alt="Lifelines" />
+      </div>
+      <div class="col col-7">
           <toast-component
           class="toast-component"
           v-if="toast"
@@ -13,6 +13,9 @@
           @toastCloseBtnClicked="clearToast">
           </toast-component>
         </div>
+      <div class="col col-1">
+        <button class="btn btn-outline-success" id="order" type="button" @click="save">Order</button>
+      </div>
     </div>
     <div class="row pt-3">
       <div class="col-12" >
@@ -44,7 +47,7 @@ import ContentView from './ContentView.vue'
 import SidebarView from './SidebarView.vue'
 import CartView from './CartView.vue'
 import ToastComponent from '../components/ToastComponent.vue'
-import { mapState, mapMutations } from 'vuex'
+import { mapState, mapMutations, mapActions } from 'vuex'
 
 export default Vue.extend({
   name: 'MainView',
@@ -62,7 +65,17 @@ export default Vue.extend({
   methods: {
     ...mapMutations([
       'clearToast'
+    ]),
+    ...mapActions([
+      'save', 'load', 'loadVariables', 'loadAssessments'
     ])
+  },
+  async created () {
+    const promises = Promise.all([this.loadVariables(), this.loadAssessments()])
+    await promises
+    if (this.$route.params.cartId) {
+      this.load(this.$route.params.cartId)
+    }
   }
 })
 </script>

--- a/tests/unit/store/actions.spec.ts
+++ b/tests/unit/store/actions.spec.ts
@@ -1,4 +1,5 @@
 import actions from '@/store/actions'
+import router from '@/router'
 import { Cart } from '@/types/Cart'
 import emptyState from '@/store/state'
 
@@ -125,6 +126,9 @@ jest.mock('@molgenis/molgenis-api-client', () => {
     post: jest.fn()
   }
 })
+jest.mock('@/router', () => ({
+  push: jest.fn()
+}))
 
 describe('actions', () => {
   describe('loadAssessments', () => {
@@ -220,6 +224,7 @@ describe('actions', () => {
   describe('save', () => {
     it('saves grid selection', async (done) => {
       const headers = { get: jest.fn() }
+      const commit = jest.fn()
       post.mockReturnValueOnce({ headers })
       headers.get.mockReturnValueOnce('https://lifelines.dev.molgenis.org/api/v1/lifelines_cart/fghij')
       const state: ApplicationState = {
@@ -232,9 +237,11 @@ describe('actions', () => {
           ageGroupAt1A: ['18-64', '65+']
         }
       }
-      await actions.save({ state })
+      await actions.save({ state, commit })
       expect(headers.get).toHaveBeenCalledWith('Location')
       expect(post).toHaveBeenCalledWith('/api/v1/lifelines_cart', { body: JSON.stringify({ contents: cartContents }) })
+      expect(commit).toHaveBeenCalledWith('setToast', {type: 'success', message: 'Saved order with id fghij'})
+      expect(router.push).toHaveBeenCalledWith({name: 'load', params: {cartId: 'fghij'}})
       done()
     })
   })

--- a/tests/unit/store/actions.spec.ts
+++ b/tests/unit/store/actions.spec.ts
@@ -1,113 +1,127 @@
 import actions from '@/store/actions'
+import { Cart } from '@/types/Cart'
+import emptyState from '@/store/state'
 
 // @ts-ignore
 import { post } from '@molgenis/molgenis-api-client'
+import ApplicationState from '@/types/ApplicationState'
 
-jest.mock('@molgenis/molgenis-api-client', () => {
-  const responses: {[key:string]: Object} = {
-    '/api/v2/lifelines_cart/fghij': {
-      selection: '{"1":[2,3]}'
-    },
-    '/api/v2/lifelines_assessment': {
-      items: [
-        { id: 1, name: '1A' },
-        { id: 2, name: '1B' }
-      ]
-    },
-    '/api/v2/lifelines_variable?attrs=id,name,label&num=10000': {
-      items: [{
+const cart: Cart = {
+  selection: [{
+    assessment: '1A',
+    variables: ['VAR1', 'VAR2']
+  }],
+  filters: {
+    ...emptyState.facetFilter,
+    ageGroupAt1A: ['18-64', '65+']
+  }
+}
+const cartContents = JSON.stringify(cart)
+const mockResponses: {[key:string]: Object} = {
+  '/api/v2/lifelines_cart/fghij': {
+    contents: cartContents
+  },
+  '/api/v2/lifelines_assessment': {
+    items: [
+      { id: 1, name: '1A' },
+      { id: 2, name: '1B' }
+    ]
+  },
+  '/api/v2/lifelines_variable?attrs=id,name,label&num=10000': {
+    items: [{
+      id: 2,
+      name: 'ARZON',
+      label: 'Suncream used'
+    }, {
+      id: 3,
+      name: 'SAF',
+      label: 'SAF'
+    }]
+  },
+  '/api/v2/lifelines_variable?attrs=id,name,label&num=10000&start=10000': {
+    items: [{
+      id: 4,
+      name: 'UVREFLECT',
+      label: 'Reflection'
+    }, {
+      id: 5,
+      name: 'ARCREME',
+      label: 'Skin cream used'
+    }]
+  },
+  '/api/v2/lifelines_subsection_variable?q=subsection_id==4&attrs=~id,id,subsection_id,variable_id(id,name,label,variants(id,assessment_id))&num=10000': {
+    items: [{
+      variable_id: {
         id: 2,
         name: 'ARZON',
-        label: 'Suncream used'
-      }, {
+        label: 'Suncream used',
+        variants: [{
+          id: 197,
+          assessment_id: 1
+        }]
+      }
+    }, {
+      variable_id: {
         id: 3,
         name: 'SAF',
-        label: 'SAF'
-      }]
-    },
-    '/api/v2/lifelines_variable?attrs=id,name,label&num=10000&start=10000': {
-      items: [{
+        label: 'SAF',
+        variants: [{
+          id: 197,
+          assessment_id: 1
+        }]
+      }
+    }, {
+      variable_id: {
         id: 4,
         name: 'UVREFLECT',
-        label: 'Reflection'
-      }, {
-        id: 5,
+        label: 'Reflection',
+        variants: [{
+          id: 197,
+          assessment_id: 1
+        }]
+      }
+    }, {
+      variable_id: {
+        id: 4,
         name: 'ARCREME',
-        label: 'Skin cream used'
-      }]
-    },
-    '/api/v2/lifelines_subsection_variable?q=subsection_id==4&attrs=~id,id,subsection_id,variable_id(id,name,label,variants(id,assessment_id))&num=10000': {
-      items: [{
-        variable_id: {
-          id: 2,
-          name: 'ARZON',
-          label: 'Suncream used',
-          variants: [{
-            id: 197,
-            assessment_id: 1
-          }]
-        }
-      }, {
-        variable_id: {
-          id: 3,
-          name: 'SAF',
-          label: 'SAF',
-          variants: [{
-            id: 197,
-            assessment_id: 1
-          }]
-        }
-      }, {
-        variable_id: {
-          id: 4,
-          name: 'UVREFLECT',
-          label: 'Reflection',
-          variants: [{
-            id: 197,
-            assessment_id: 1
-          }]
-        }
-      }, {
-        variable_id: {
-          id: 4,
-          name: 'ARCREME',
-          label: 'Skin cream used',
-          variants: [{
-            id: 197,
-            assessment_id: 1
-          }]
-        }
-      }]
-    },
-    '/api/v2/lifelines_who_when?aggs=x==variant_id&q=ll_nr.yob%3Dle%3D1970': {
-      aggs: {
-        matrix: [[1234], [5678]],
-        xLabels: [{
-          assessment_id: '1',
-          id: '1'
-        }, {
-          assessment_id: '2',
-          id: '10'
-        }
-        ]
+        label: 'Skin cream used',
+        variants: [{
+          id: 197,
+          assessment_id: 1
+        }]
       }
-    },
-    '/api/v2/lifelines_who_when?aggs=x==variant_id': {
-      aggs: {
-        matrix: [[12340], [56780]],
-        xLabels: [{
-          assessment_id: '1',
-          id: '1'
-        }, {
-          assessment_id: '2',
-          id: '10'
-        }
-        ]
+    }]
+  },
+  '/api/v2/lifelines_who_when?aggs=x==variant_id&q=ll_nr.yob%3Dle%3D1970': {
+    aggs: {
+      matrix: [[1234], [5678]],
+      xLabels: [{
+        assessment_id: '1',
+        id: '1'
+      }, {
+        assessment_id: '2',
+        id: '10'
       }
+      ]
+    }
+  },
+  '/api/v2/lifelines_who_when?aggs=x==variant_id': {
+    aggs: {
+      matrix: [[12340], [56780]],
+      xLabels: [{
+        assessment_id: '1',
+        id: '1'
+      }, {
+        assessment_id: '2',
+        id: '10'
+      }
+      ]
     }
   }
+}
+jest.mock('@molgenis/molgenis-api-client', () => {
   return {
-    get: (url: string) => Promise.resolve(responses[url]),
+    get: (url: string) => Promise.resolve(mockResponses[url]),
     post: jest.fn()
   }
 })
@@ -208,9 +222,19 @@ describe('actions', () => {
       const headers = { get: jest.fn() }
       post.mockReturnValueOnce({ headers })
       headers.get.mockReturnValueOnce('https://lifelines.dev.molgenis.org/api/v1/lifelines_cart/fghij')
-      await actions.save({ state: { gridSelection: { 1: [2, 3] } } })
+      const state: ApplicationState = {
+        ...emptyState,
+        assessments: { 1: { id: 1, name: '1A' } },
+        variables: { 1: { id: 1, name: 'VAR1', label: 'Variable 1' }, 2: { id: 2, name: 'VAR2', label: 'Variable 2' } },
+        gridSelection: { 1: [1], 2: [1] },
+        facetFilter: {
+          ...emptyState.facetFilter,
+          ageGroupAt1A: ['18-64', '65+']
+        }
+      }
+      await actions.save({ state })
       expect(headers.get).toHaveBeenCalledWith('Location')
-      expect(post).toHaveBeenCalledWith('/api/v1/lifelines_cart', { body: '{"selection":"{\\"1\\":[2,3]}"}' })
+      expect(post).toHaveBeenCalledWith('/api/v1/lifelines_cart', { body: JSON.stringify({ contents: cartContents }) })
       done()
     })
   })
@@ -218,8 +242,14 @@ describe('actions', () => {
   describe('load', () => {
     it('loads grid selection', async (done) => {
       const commit = jest.fn()
-      await actions.load({ commit }, 'fghij')
-      expect(commit).toHaveBeenCalledWith('updateGridSelection', { 1: [2, 3] })
+      const state: ApplicationState = {
+        ...emptyState,
+        assessments: { 1: { id: 1, name: '1A' } },
+        variables: { 1: { id: 1, name: 'VAR1', label: 'Variable 1' }, 2: { id: 2, name: 'VAR2', label: 'Variable 2' } }
+      }
+      await actions.load({ commit, state }, 'fghij')
+      expect(commit).toHaveBeenCalledWith('updateGridSelection', { 1: [1], 2: [1] })
+      expect(commit).toHaveBeenCalledWith('updateFacetFilter', { ...emptyState.facetFilter, ageGroupAt1A: ['18-64', '65+'] })
       done()
     })
   })

--- a/tests/unit/views/MainView.spec.ts
+++ b/tests/unit/views/MainView.spec.ts
@@ -6,31 +6,57 @@ describe('MainView.vue', () => {
   const localVue = createLocalVue()
   localVue.use(Vuex)
   let store: any
+  let actions: any
+  let state: any
+  const mocks: any = { '$route': { params: {} } }
 
   beforeEach(() => {
-    let state: any
-
     state = {
       toast: { type: 'danger', message: 'i am not a message' }
     }
-
+    actions = {
+      loadVariables: jest.fn(),
+      loadAssessments: jest.fn(),
+      load: jest.fn(),
+      save: jest.fn()
+    }
     store = new Vuex.Store({
-      state
+      state,
+      actions
     })
   })
 
   it('renders sidebar and content', () => {
-    const wrapper = shallowMount(MainView, { store, localVue })
+    const wrapper = shallowMount(MainView, { store, localVue, mocks })
 
     expect(wrapper.exists()).toBeTruthy()
     expect(wrapper.find('#main-view').exists()).toBeTruthy()
   })
 
   it('has a toast component that gets passed a type and message', () => {
-    const wrapper = shallowMount(MainView, { store, localVue })
+    const wrapper = shallowMount(MainView, { store, localVue, mocks })
 
     expect(wrapper.find('toast-component-stub').exists()).toBeTruthy()
     expect(wrapper.find('toast-component-stub').attributes('type')).toEqual('danger')
     expect(wrapper.find('toast-component-stub').attributes('message')).toEqual('i am not a message')
+  })
+
+  it('renders an order button that saves the current order', () => {
+    const wrapper = shallowMount(MainView, { store, localVue, mocks })
+    wrapper.find('#order').trigger('click')
+    expect(actions.save).toHaveBeenCalled()
+  })
+
+  it('loads an order, after loading variables and assessments, if a cartId route param is present', (done) => {
+    actions.loadVariables.mockReturnValueOnce(Promise.resolve())
+    actions.loadAssessments.mockReturnValueOnce(Promise.resolve())
+
+    mocks.$route.params.cartId = 'abcde'
+    const wrapper = shallowMount(MainView, { store, localVue, mocks })
+
+    setTimeout(() => {
+      expect(actions.load).toHaveBeenCalledWith(expect.anything(), 'abcde', undefined)
+      done()
+    }, 0)
   })
 })


### PR DESCRIPTION
Was a bit more intricate than I initially thought because the grid selection in the store is `{[variableId]: [assessmentId]}` and the structure in the cart is `{assessmentName, variables: [variableName]}`.
So we need to convert both id to name and back again and switch from grouping by variable to grouping by assessment and back again.

I've assumed that the facet filters can be copied over unchanged from the store but this may be mistaken because in the store we also have keys for empty filters.

#### Checklist
- [ ] Functionality works & meets specifications
- [ ] Code reviewed
- [ ] Code unit/integration/system tested
- [ ] User documentation updated
- [ ] Conventional commits (squash if needed)
- [ ] No warnings during install
- [ ] Updated javascript typing
