### PR TITLE
feat(store): filter tree and variables

### DIFF
--- a/src/store/actions.ts
+++ b/src/store/actions.ts
@@ -7,6 +7,7 @@ import { Section } from '@/types/Section.ts'
 import { Cart } from '@/types/Cart'
 import ApplicationState from '@/types/ApplicationState'
 import router from '@/router'
+import Getters from '@/types/Getters'
 
 export default {
   loadSections: tryAction(async ({ commit, state } : any) => {
@@ -44,6 +45,29 @@ export default {
       commit('updateSectionTree', treeStructure)
     }
   }),
+  filterSections: tryAction(async ({ getters, commit }: {getters: Getters, commit: any}) => {
+    console.log('filterSections')
+    const q = getters.searchTermQuery
+    if (q === null) {
+      commit('updateFilteredSections', null)
+    } else {
+      const response = await api.get(`/api/v2/lifelines_section?q=${encodeURIComponent(q)}`)
+      if (q === getters.searchTermQuery) {
+        commit('updateFilteredSections', response.items.map((it: any) => it.id))
+      }
+    }
+  }),
+  filterSubsections: tryAction(async ({ getters, commit }: {getters: Getters, commit: any}) => {
+    const q = getters.searchTermQuery
+    if (q === null) {
+      commit('updateFiteredSubsections', null)
+    } else {
+      const response = await api.get(`/api/v2/lifelines_subsection_variable?aggs=x==subsection_agg&q=${encodeURIComponent(q)}`)
+      if (q === getters.searchTermQuery) {
+        commit('updateFiteredSubsections', response.aggs.xLabels.map((label: string) => parseInt(label, 10)))
+      }
+    }
+  }),
   loadAssessments: tryAction(async ({ commit }: any) => {
     const response = await api.get('/api/v2/lifelines_assessment')
     commit('updateAssessments', response.items.reduce((accum: { [key:number]: Assessment }, assessment: Assessment) => {
@@ -64,11 +88,16 @@ export default {
       }, {})
     commit('updateVariables', variableMap)
   }),
-  loadGridVariables: tryAction(async ({ state, commit } : any) => {
+  loadGridVariables: tryAction(async ({ state, commit, getters } : { state: ApplicationState, commit: any, getters: Getters}) => {
     commit('updateGridVariables', [])
     const subsectionId = state.treeSelected
-    const response = await api.get(`/api/v2/lifelines_subsection_variable?q=subsection_id==${subsectionId}&attrs=~id,id,subsection_id,variable_id(id,name,label,variants(id,assessment_id))&num=10000&sort=variable_id`)
-    if (state.treeSelected === subsectionId) {
+    const searchTermQuery = getters.searchTermQuery
+    let q = `subsection_id==${subsectionId}`
+    if (searchTermQuery !== null) {
+      q = `${q};${searchTermQuery}`
+    }
+    const response = await api.get(`/api/v2/lifelines_subsection_variable?q=${q}&attrs=~id,id,subsection_id,variable_id(id,name,label,variants(id,assessment_id))&num=10000&sort=variable_id`)
+    if ((state.treeSelected === subsectionId) && (searchTermQuery === getters.searchTermQuery)) {
       commit('updateGridVariables', response.items
       // map assessment_id to assessmentId somewhere deep in the structure
         .map((sv: any) => ({

--- a/src/store/actions.ts
+++ b/src/store/actions.ts
@@ -93,7 +93,7 @@ export default {
     if (searchTermQuery !== null) {
       q = `${q};${searchTermQuery}`
     }
-    const response = await api.get(`/api/v2/lifelines_subsection_variable?q=${q}&attrs=~id,id,subsection_id,variable_id(id,name,label,variants(id,assessment_id))&num=10000&sort=variable_id`)
+    const response = await api.get(`/api/v2/lifelines_subsection_variable?q=${encodeURIComponent(q)}&attrs=~id,id,subsection_id,variable_id(id,name,label,variants(id,assessment_id))&num=10000&sort=variable_id`)
     if ((state.treeSelected === subsectionId) && (searchTermQuery === getters.searchTermQuery)) {
       commit('updateGridVariables', response.items
       // map assessment_id to assessmentId somewhere deep in the structure

--- a/src/store/actions.ts
+++ b/src/store/actions.ts
@@ -46,12 +46,10 @@ export default {
     }
   }),
   filterSections: tryAction(async ({ getters, commit }: {getters: Getters, commit: any}) => {
-    console.log('filterSections')
     const q = getters.searchTermQuery
-    if (q === null) {
-      commit('updateFilteredSections', null)
-    } else {
-      const response = await api.get(`/api/v2/lifelines_section?q=${encodeURIComponent(q)}`)
+    commit('updateFilteredSections', null)
+    if (q !== null) {
+      const response = await api.get(`/api/v2/lifelines_section?num=10000&q=${encodeURIComponent(q)}`)
       if (q === getters.searchTermQuery) {
         commit('updateFilteredSections', response.items.map((it: any) => it.id))
       }
@@ -59,12 +57,11 @@ export default {
   }),
   filterSubsections: tryAction(async ({ getters, commit }: {getters: Getters, commit: any}) => {
     const q = getters.searchTermQuery
-    if (q === null) {
-      commit('updateFiteredSubsections', null)
-    } else {
+    commit('updateFilteredSubsections', null)
+    if (q !== null) {
       const response = await api.get(`/api/v2/lifelines_subsection_variable?aggs=x==subsection_agg&q=${encodeURIComponent(q)}`)
       if (q === getters.searchTermQuery) {
-        commit('updateFiteredSubsections', response.aggs.xLabels.map((label: string) => parseInt(label, 10)))
+        commit('updateFilteredSubsections', response.aggs.xLabels.map((label: string) => parseInt(label, 10)))
       }
     }
   }),

--- a/src/store/getters.ts
+++ b/src/store/getters.ts
@@ -5,6 +5,8 @@ import Getters from '@/types/Getters'
 import Variant from '@/types/Variant'
 import { Variable, VariableWithVariants } from '@/types/Variable'
 import Assessment from '@/types/Assessment'
+import { TreeNode } from '@/types/TreeNode'
+import { Section } from '@/types/Section'
 
 export default {
   variants: (state: ApplicationState): Variant[] =>
@@ -129,5 +131,22 @@ export default {
     }
 
     return []
-  }
+  },
+  filteredTreeStructure: ({ filteredSections, filteredSubsections }: ApplicationState, { treeStructure }: Getters) => {
+    if (filteredSections === null || filteredSubsections === null) {
+      return treeStructure
+    }
+    return treeStructure.reduce((result: TreeNode[], section: TreeNode) => {
+      if (filteredSections.includes(section.id)) {
+        result.push(section)
+      } else {
+        const filteredChildren = section.children.filter(({ id }) => filteredSubsections.includes(id))
+        if (filteredChildren.length > 0) {
+          result.push({ ...section, children: filteredChildren })
+        }
+      }
+      return result
+    }, [])
+  },
+  searchTermQuery: (state: ApplicationState) => state.searchTerm && transformToRSQL({ selector: '*', comparison: '=q=', arguments: state.searchTerm })
 }

--- a/src/store/mutations.ts
+++ b/src/store/mutations.ts
@@ -72,6 +72,15 @@ export default {
   updateGridSelection (state: ApplicationState, gridSelection: GridSelection) {
     state.gridSelection = gridSelection
   },
+  updateSearchTerm (state: ApplicationState, searchTerm: string|null) {
+    state.searchTerm = searchTerm
+  },
+  updateFilteredSections (state: ApplicationState, sections: number[]) {
+    state.filteredSections = sections
+  },
+  updateFiteredSubsections (state: ApplicationState, subsections: number[]) {
+    state.filteredSubsections = subsections
+  },
   toggleGridColumn ({ gridSelection, gridVariables }: {gridSelection: GridSelection, gridVariables: Variable[]}, { assessmentId } : {assessmentId: number}) {
     const allSelected = gridVariables.every((variable) => gridSelection.hasOwnProperty(variable.id) && gridSelection[variable.id].includes(assessmentId))
     if (allSelected) {

--- a/src/store/mutations.ts
+++ b/src/store/mutations.ts
@@ -78,7 +78,7 @@ export default {
   updateFilteredSections (state: ApplicationState, sections: number[]) {
     state.filteredSections = sections
   },
-  updateFiteredSubsections (state: ApplicationState, subsections: number[]) {
+  updateFilteredSubsections (state: ApplicationState, subsections: number[]) {
     state.filteredSubsections = subsections
   },
   toggleGridColumn ({ gridSelection, gridVariables }: {gridSelection: GridSelection, gridVariables: Variable[]}, { assessmentId } : {assessmentId: number}) {

--- a/src/store/state.ts
+++ b/src/store/state.ts
@@ -40,7 +40,10 @@ const state: ApplicationState = {
   gridSelection: {},
   variantCounts: [],
   participantCount: null,
-  assessments: {}
+  assessments: {},
+  searchTerm: null,
+  filteredSubsections: null,
+  filteredSections: null
 }
 
 export default state

--- a/src/types/ApplicationState.ts
+++ b/src/types/ApplicationState.ts
@@ -29,4 +29,7 @@ export default interface ApplicationState {
   treeSelected: number
   treeOpenSection: string
   gridSelection: GridSelection
+  searchTerm: string | null
+  filteredSubsections: number[] | null
+  filteredSections: number[] | null
 }

--- a/src/types/Getters.ts
+++ b/src/types/Getters.ts
@@ -1,5 +1,6 @@
 import Assessment from '@/types/Assessment'
 import GridCell from '@/types/GridCell'
+import { TreeNode } from './TreeNode'
 import Variant from './Variant'
 
 export default interface Getters {
@@ -8,4 +9,6 @@ export default interface Getters {
   rsql: string
   gridAssessments: Assessment[]
   grid: number[][]
+  searchTermQuery: string | null
+  treeStructure: TreeNode[]
 }

--- a/src/types/TreeNode.ts
+++ b/src/types/TreeNode.ts
@@ -1,0 +1,8 @@
+import { Section } from './Section'
+
+export interface TreeNode extends Section {
+  children: {
+    name: string
+    id: number
+  }[]
+}

--- a/src/views/ContentView.vue
+++ b/src/views/ContentView.vue
@@ -5,7 +5,7 @@
            <h3 class="my-3">2. Select data</h3>
           </div>
           <div class="col-span-4 col-4" >
-            <search-component v-model="searchValue"></search-component>
+            <search-component @seachChanged="onSearchChange"></search-component>
           </div>
       </div>
       <div class="row mt-3" >
@@ -25,13 +25,22 @@ import Vue from 'vue'
 import TreeView from './TreeView.vue'
 import GridView from './GridView.vue'
 import SearchComponent from '../components/search/SearchComponent.vue'
+import { mapMutations, mapActions, mapState } from 'vuex'
 
 export default Vue.extend({
   name: 'ContentView',
   components: { TreeView, GridView, SearchComponent },
-  data: () => {
-    return {
-      searchValue: ''
+  computed: mapState(['treeSelection']),
+  methods: {
+    ...mapMutations(['updateSearchTerm']),
+    ...mapActions(['filterSections', 'filterSubsections', 'loadGridVariables']),
+    onSearchChange (value) {
+      this.updateSearchTerm(value || null)
+      this.filterSections()
+      this.filterSubsections()
+      if (this.treeSelection !== -1) {
+        this.loadGridVariables()
+      }
     }
   }
 })

--- a/src/views/TreeView.vue
+++ b/src/views/TreeView.vue
@@ -2,7 +2,7 @@
   <div id="tree-view">
     <collapsible-tree
       :selection="treeSelected"
-      :structure="treeStructure"
+      :structure="filteredTreeStructure"
       :opensection="treeOpenSection"
       @updateselection="updateSelection"
       @updateopensection="updateOpenSection" />
@@ -23,7 +23,7 @@ export default Vue.extend({
     }
   },
   computed: {
-    ...mapGetters(['treeStructure']),
+    ...mapGetters(['filteredTreeStructure']),
     ...mapState(['treeSelected', 'treeOpenSection'])
   },
   methods: {

--- a/tests/unit/store/actions.spec.ts
+++ b/tests/unit/store/actions.spec.ts
@@ -27,6 +27,19 @@ const mockResponses: {[key:string]: Object} = {
       { id: 2, name: 'section2' }
     ]
   },
+  '/api/v2/lifelines_section?num=10000&q=*%3Dq%3Dhello': {
+    items: [
+      { id: 1, name: 'section1' }
+    ]
+  },
+  '/api/v2/lifelines_subsection_variable?aggs=x==subsection_agg&q=*%3Dq%3Dhello': {
+    aggs: {
+      xLabels: [
+        '1',
+        '3'
+      ]
+    }
+  },
   '/api/v2/lifelines_sub_section?num=10000': {
     items: [
       { id: 1, name: 'sub_section1' },
@@ -87,6 +100,29 @@ const mockResponses: {[key:string]: Object} = {
         id: 4,
         name: 'UVREFLECT',
         label: 'Reflection',
+        variants: [{
+          id: 197,
+          assessment_id: 1
+        }]
+      }
+    }, {
+      variable_id: {
+        id: 4,
+        name: 'ARCREME',
+        label: 'Skin cream used',
+        variants: [{
+          id: 197,
+          assessment_id: 1
+        }]
+      }
+    }]
+  },
+  '/api/v2/lifelines_subsection_variable?q=subsection_id==4;*=q=cream&attrs=~id,id,subsection_id,variable_id(id,name,label,variants(id,assessment_id))&num=10000&sort=variable_id': {
+    items: [{
+      variable_id: {
+        id: 2,
+        name: 'ARZON',
+        label: 'Suncream used',
         variants: [{
           id: 197,
           assessment_id: 1
@@ -167,6 +203,58 @@ describe('actions', () => {
     })
   })
 
+  describe('filterSections', () => {
+    it('loads sections matching search term', async (done) => {
+      const commit = jest.fn()
+      const getters = {
+        searchTermQuery: '*=q=hello'
+      }
+      const action = actions.filterSections({ commit, getters })
+      expect(commit).toHaveBeenCalledWith('updateFilteredSections', null)
+      await action
+      expect(commit).toHaveBeenCalledWith('updateFilteredSections', [1])
+      done()
+    })
+
+    it('does not commit if search term has changed while loading', async (done) => {
+      const commit = jest.fn()
+      const getters = {
+        searchTermQuery: '*=q=hello'
+      }
+      const action = actions.filterSections({ commit, getters })
+      expect(commit).toHaveBeenCalledWith('updateFilteredSections', null)
+      getters.searchTermQuery = '*=q=helloes'
+      await action
+      expect(commit).toHaveBeenCalledTimes(1)
+      done()
+    })
+  })
+
+  describe('filterSubsections', () => {
+    it('loads subsections matching search term', async (done) => {
+      const commit = jest.fn()
+      const getters = {
+        searchTermQuery: '*=q=hello'
+      }
+      const action = actions.filterSubsections({ commit, getters })
+      expect(commit).toHaveBeenCalledWith('updateFilteredSubsections', null)
+      await action
+      expect(commit).toHaveBeenCalledWith('updateFilteredSubsections', [1, 3])
+      done()
+    })
+
+    it('clears filtered subsections if search term is null', async (done) => {
+      const commit = jest.fn()
+      const getters = {
+        searchTermQuery: null
+      }
+      await actions.filterSubsections({ commit, getters })
+      expect(commit).toHaveBeenCalledWith('updateFilteredSubsections', null)
+      expect(commit).toHaveBeenCalledTimes(1)
+      done()
+    })
+  })
+
   describe('loadSubSections', () => {
     it('fetch the sub sections and commits them as a string list', async (done) => {
       const commit = jest.fn()
@@ -202,7 +290,11 @@ describe('actions', () => {
   describe('loadGridVariables', () => {
     it('loads variables for selected subsection', async (done) => {
       const commit = jest.fn()
-      const action = actions.loadGridVariables({ state: { treeSelected: 4 }, commit })
+      const action = actions.loadGridVariables({
+        state: { treeSelected: 4 },
+        getters: { searchTermQuery: null },
+        commit
+      })
       expect(commit).toHaveBeenCalledWith('updateGridVariables', [])
       await action
       const variant = { 'assessmentId': 1, 'assessment_id': 1, 'id': 197 }
@@ -214,12 +306,41 @@ describe('actions', () => {
       ])
       done()
     })
+    it('adds searchTermQuery to query if it is present', async (done) => {
+      const commit = jest.fn()
+      const action = actions.loadGridVariables({
+        state: { treeSelected: 4 },
+        getters: { searchTermQuery: '*=q=cream' },
+        commit
+      })
+      expect(commit).toHaveBeenCalledWith('updateGridVariables', [])
+      await action
+      const variant = { 'assessmentId': 1, 'assessment_id': 1, 'id': 197 }
+      expect(commit).toHaveBeenCalledWith('updateGridVariables', [
+        { 'id': 2, 'label': 'Suncream used', 'name': 'ARZON', 'variants': [variant] },
+        { 'id': 4, 'label': 'Skin cream used', 'name': 'ARCREME', 'variants': [variant] }
+      ])
+      done()
+    })
     it('does not commit the grid variables if the tree selection changes during the call', async (done) => {
       const commit = jest.fn()
       const state = { treeSelected: 4 }
-      const action = actions.loadGridVariables({ state, commit })
+      const getters = { searchTermQuery: null }
+      const action = actions.loadGridVariables({ state, commit, getters })
       expect(commit).toHaveBeenCalledWith('updateGridVariables', [])
       state.treeSelected = 6
+      await action
+      expect(commit).toHaveBeenCalledTimes(1)
+      done()
+    })
+
+    it('does not commit the grid variables if the search term query during the call', async (done) => {
+      const commit = jest.fn()
+      const state = { treeSelected: 4 }
+      const getters: any = { searchTermQuery: null }
+      const action = actions.loadGridVariables({ state, commit, getters })
+      expect(commit).toHaveBeenCalledWith('updateGridVariables', [])
+      getters.searchTermQuery = '*=q=test'
       await action
       expect(commit).toHaveBeenCalledTimes(1)
       done()

--- a/tests/unit/store/actions.spec.ts
+++ b/tests/unit/store/actions.spec.ts
@@ -74,7 +74,7 @@ const mockResponses: {[key:string]: Object} = {
       label: 'Skin cream used'
     }]
   },
-  '/api/v2/lifelines_subsection_variable?q=subsection_id==4&attrs=~id,id,subsection_id,variable_id(id,name,label,variants(id,assessment_id))&num=10000&sort=variable_id': {
+  '/api/v2/lifelines_subsection_variable?q=subsection_id%3D%3D4&attrs=~id,id,subsection_id,variable_id(id,name,label,variants(id,assessment_id))&num=10000&sort=variable_id': {
     items: [{
       variable_id: {
         id: 2,
@@ -117,7 +117,7 @@ const mockResponses: {[key:string]: Object} = {
       }
     }]
   },
-  '/api/v2/lifelines_subsection_variable?q=subsection_id==4;*=q=cream&attrs=~id,id,subsection_id,variable_id(id,name,label,variants(id,assessment_id))&num=10000&sort=variable_id': {
+  '/api/v2/lifelines_subsection_variable?q=subsection_id%3D%3D4%3B*%3Dq%3Dcream&attrs=~id,id,subsection_id,variable_id(id,name,label,variants(id,assessment_id))&num=10000&sort=variable_id': {
     items: [{
       variable_id: {
         id: 2,

--- a/tests/unit/store/getters.spec.ts
+++ b/tests/unit/store/getters.spec.ts
@@ -5,6 +5,8 @@ import ApplicationState from '@/types/ApplicationState'
 import Variant from '@/types/Variant'
 import Assessment from '@/types/Assessment'
 import { Variable, VariableWithVariants } from '@/types/Variable'
+import { Section } from '@/types/Section'
+import { TreeNode } from '@/types/TreeNode'
 
 describe('getters', () => {
   const emptyGetters: Getters = {
@@ -268,6 +270,47 @@ describe('getters', () => {
 
       it('should escape rsql characters', () => {
         expect(getters.searchTermQuery({ ...emptyState, searchTerm: 'a==b' })).toBe('*=q=\'a==b\'')
+      })
+    })
+
+    describe('filteredTreeStructure', () => {
+      const education: TreeNode = {
+        id: 1,
+        name: 'Education',
+        children: [
+          { id: 1, name: 'Primary education' },
+          { id: 2, name: 'Secondary education' }
+        ]
+      }
+      const breakfast = { id: 3, name: 'Breakfast' }
+      const lunch = { id: 4, name: 'Lunch' }
+      const dinner = { id: 5, name: 'Dinner' }
+      const food: TreeNode = {
+        id: 2,
+        name: 'Food',
+        children: [ breakfast, lunch, dinner ]
+      }
+      const treeStructure = [education, food]
+
+      it('does not filter if there are no filters', () => {
+        const result = getters.filteredTreeStructure(
+          { ...emptyState, filteredSections: null, filteredSubsections: null },
+          { ...emptyGetters, treeStructure })
+        expect(result).toEqual(treeStructure)
+      })
+
+      it('filters the tree if there are filters', () => {
+        const result = getters.filteredTreeStructure(
+          { ...emptyState, filteredSections: [], filteredSubsections: [4] },
+          { ...emptyGetters, treeStructure })
+        expect(result).toEqual([{ ...food, children: [lunch] }])
+      })
+
+      it('prunes empty sections when filtering', () => {
+        const result = getters.filteredTreeStructure(
+          { ...emptyState, filteredSections: [1], filteredSubsections: [4] },
+          { ...emptyGetters, treeStructure })
+        expect(result).toEqual([education, { ...food, children: [lunch] }])
       })
     })
   })

--- a/tests/unit/store/getters.spec.ts
+++ b/tests/unit/store/getters.spec.ts
@@ -12,7 +12,9 @@ describe('getters', () => {
     variantIds: [],
     rsql: '',
     grid: [],
-    gridAssessments: []
+    gridAssessments: [],
+    searchTermQuery: null,
+    treeStructure: []
   }
 
   const variant1: Variant = { id: 1, assessmentId: 1 }
@@ -252,6 +254,20 @@ describe('getters', () => {
       }
       it('should return the complete tree structure', () => {
         expect(getters.treeStructure(state, gettersParam)).toEqual([{ 'children': [{ 'id': 0, 'name': 'sub-section1' }], 'id': 1, 'name': 'section' }])
+      })
+    })
+
+    describe('searchTermQuery', () => {
+      it('should be null if the search term is null', () => {
+        expect(getters.searchTermQuery(emptyState)).toBeNull()
+      })
+
+      it('should give rsql for the search term', () => {
+        expect(getters.searchTermQuery({ ...emptyState, searchTerm: 'hello' })).toBe('*=q=hello')
+      })
+
+      it('should escape rsql characters', () => {
+        expect(getters.searchTermQuery({ ...emptyState, searchTerm: 'a==b' })).toBe('*=q=\'a==b\'')
       })
     })
   })

--- a/tests/unit/store/mutations.spec.ts
+++ b/tests/unit/store/mutations.spec.ts
@@ -19,16 +19,16 @@ describe('mutations', () => {
   describe('updateFilteredSections', () => {
     it('updates filtered sections', () => {
       const baseAppState = { ...state }
-      mutations.updateFilteredSections(baseAppState, [1,2])
-      expect(baseAppState.filteredSections).toEqual([1,2])
+      mutations.updateFilteredSections(baseAppState, [1, 2])
+      expect(baseAppState.filteredSections).toEqual([1, 2])
     })
   })
 
   describe('updateFilteredSubsections', () => {
     it('updates filtered subsections', () => {
       const baseAppState = { ...state }
-      mutations.updateFilteredSubsections(baseAppState, [1,2])
-      expect(baseAppState.filteredSubsections).toEqual([1,2])
+      mutations.updateFilteredSubsections(baseAppState, [1, 2])
+      expect(baseAppState.filteredSubsections).toEqual([1, 2])
     })
   })
 

--- a/tests/unit/store/mutations.spec.ts
+++ b/tests/unit/store/mutations.spec.ts
@@ -16,6 +16,22 @@ describe('mutations', () => {
     })
   })
 
+  describe('updateFilteredSections', () => {
+    it('updates filtered sections', () => {
+      const baseAppState = { ...state }
+      mutations.updateFilteredSections(baseAppState, [1,2])
+      expect(baseAppState.filteredSections).toEqual([1,2])
+    })
+  })
+
+  describe('updateFilteredSubsections', () => {
+    it('updates filtered subsections', () => {
+      const baseAppState = { ...state }
+      mutations.updateFilteredSubsections(baseAppState, [1,2])
+      expect(baseAppState.filteredSubsections).toEqual([1,2])
+    })
+  })
+
   describe('updateSearchTerm', () => {
     it('updates search term', () => {
       const baseAppState = { ...state }

--- a/tests/unit/store/mutations.spec.ts
+++ b/tests/unit/store/mutations.spec.ts
@@ -16,6 +16,20 @@ describe('mutations', () => {
     })
   })
 
+  describe('updateSearchTerm', () => {
+    it('updates search term', () => {
+      const baseAppState = { ...state }
+      mutations.updateSearchTerm(baseAppState, 'hello')
+      expect(baseAppState.searchTerm).toEqual('hello')
+    })
+
+    it('removes search term', () => {
+      const baseAppState = { ...state }
+      mutations.updateSearchTerm(baseAppState, null)
+      expect(baseAppState.searchTerm).toEqual(null)
+    })
+  })
+
   describe('setToast', () => {
     it('replace the toast with the passed toast', () => {
       let baseAppState = Object.assign({}, state)

--- a/tests/unit/views/ContentView.spec.ts
+++ b/tests/unit/views/ContentView.spec.ts
@@ -1,14 +1,45 @@
-import { shallowMount } from '@vue/test-utils'
+import { shallowMount, createLocalVue } from '@vue/test-utils'
 import ContentView from '@/views/ContentView.vue'
-import Vue from 'vue'
+import Vuex, { Store } from 'vuex'
+import SearchComponent from '@/components/search/SearchComponent.vue'
+import mutations from '@/store/mutations';
 
-Vue.filter('i18n', (value: string) => value) // Add dummy filter for i18n
+const localVue = createLocalVue()
+localVue.use(Vuex)
 
 describe('ContentView.vue', () => {
+
+  const filterSections = jest.fn()
+  const filterSubsections = jest.fn()
+  const loadGridVariables = jest.fn()
+  const updateSearchTerm = jest.fn()
+  const store = new Store({
+    state: { treeSelection: 3 },
+    actions: {
+      filterSections,
+      filterSubsections,
+      loadGridVariables
+    },
+    mutations: {
+      updateSearchTerm
+    }
+  })
+
   it('Renders the content', () => {
     const wrapper = shallowMount(ContentView)
 
     expect(wrapper.exists()).toBeTruthy()
     expect(wrapper.find('#Content-view').exists()).toBeTruthy()
+  })
+
+  it('updates search term and dispatches filter actions when the search term changes', () => {
+    const wrapper = shallowMount(ContentView, { store, localVue })
+
+    wrapper.find(SearchComponent).vm.$emit('seachChanged', 'mini')
+
+    expect(updateSearchTerm).toHaveBeenCalled()
+    expect(filterSections).toHaveBeenCalled()
+    expect(filterSubsections).toHaveBeenCalled()
+    expect(loadGridVariables).toHaveBeenCalled()
   })
 })

--- a/tests/unit/views/ContentView.spec.ts
+++ b/tests/unit/views/ContentView.spec.ts
@@ -2,13 +2,12 @@ import { shallowMount, createLocalVue } from '@vue/test-utils'
 import ContentView from '@/views/ContentView.vue'
 import Vuex, { Store } from 'vuex'
 import SearchComponent from '@/components/search/SearchComponent.vue'
-import mutations from '@/store/mutations';
+import mutations from '@/store/mutations'
 
 const localVue = createLocalVue()
 localVue.use(Vuex)
 
 describe('ContentView.vue', () => {
-
   const filterSections = jest.fn()
   const filterSubsections = jest.fn()
   const loadGridVariables = jest.fn()

--- a/tests/unit/views/TreeView.spec.ts
+++ b/tests/unit/views/TreeView.spec.ts
@@ -24,7 +24,7 @@ describe('TreeView.vue', () => {
   beforeEach(() => {
     store = new Vuex.Store({
       getters: {
-        treeStructure: () => [{
+        filteredTreeStructure: () => [{
           name: 'parent',
           open: true,
           children: [


### PR DESCRIPTION
# store
First commit changes only the store (everything is null if it is not currently active):
## search term
* `state.searchTerm` contains the search term. I assumed it is a single string to keep things simple.
* `getters.searchTermQuery` transforms it to search criteria. I've picked a first simple `*=q=${searchTerm}`. If folks want more we can update this to e.g. convert search string `'foo bar'` to `*=q='foo',*=q='bar'`
## tree
* `state.filteredSections` contains the IDs of sections that match the search term
* `state.filteredSubsections` contains the IDs of subsections that either
  * match the search term or 
  * contain variables that match the search term
* `actions.filterSections` and `actions.filterSubsections` fetch these arrays using the `searchTermQuery`
* `getters.filteredTreeStructure` filters `getters.treeStructure` based on the filters in the state
## grid
* `actions.loadGridVariables` is updated to add `searchTermQuery` to the query if one is present. This worked so quickly out of the box that I could hardly believe it :D

# view
Second commit contains a first rugged link of the store changes to the view so that we can actually see something happening.
* Writes search term changes to store and triggers the actions that fetch the filter lists.
* Fetches filtered grid if it is present
* Shows filteredTreeStructure instead of treeStructure in the TreeView

This is not yet complete, for instance
* TreeView now shows a spinner if nothing matches the search term and the filtered tree structure is empty
* TreeView does not like it if we update the tree when it's expanded. Some of the nodes end up with weird height

#### Checklist
- [ ] Functionality works & meets specifications
- [ ] Code reviewed
- [ ] Code unit/integration/system tested
- [ ] User documentation updated
- [ ] Conventional commits (squash if needed)
- [ ] No warnings during install
- [ ] Updated javascript typing
