### PR TITLE
feat: store tree state

### DIFF
--- a/src/components/tree/CollapsibleTree.vue
+++ b/src/components/tree/CollapsibleTree.vue
@@ -19,16 +19,16 @@
               <collapse-tree-icon
                 v-if="hasChildren(parent)"
                 class="mr-2"
-                :state="parent.name == collapsed"
+                :state="parent.name == value.open"
               />
               <span v-if="parent.count" class="badge badge-pill badge-light float-right align-self-center">{{parent.count}}</span>
             </div>
           </div>
         </li>
-        <block-expand :key="'b-'+ parent.name" :isExpanded="parent.name == collapsed && hasChildren(parent)" class="list-group-item p-0" >
+        <block-expand :key="'b-'+ parent.name" :isExpanded="parent.name == value.open && hasChildren(parent)" class="list-group-item p-0" >
           <ul class="list-group list-group-flush">
             <li
-              :class="(value===child.id)&&'active'"
+              :class="(value.selection===child.id)&&'active'"
               class="list-group-item list-group-item-outline-secondary list-group-item-action py-1 child-list"
               role="button"
               v-for="child in parent.children"
@@ -61,14 +61,9 @@ import BlockExpand from '../animations/BlockExpand.vue'
 
 export default Vue.extend({
   name: 'CollapsibleTree',
-  data: function () {
-    return {
-      collapsed: ''
-    }
-  },
   props: {
     value: {
-      type: Number,
+      type: Object,
       required: true
     },
     structure: {
@@ -83,13 +78,13 @@ export default Vue.extend({
   },
   methods: {
     selectElement (id) {
-      this.$emit('input', id)
+      this.$emit('input', { selected: id, open: this.value.open })
     },
     toggleCollapse (name) {
-      if (this.collapsed === name) {
-        this.collapsed = ''
+      if (this.value.open === name) {
+        this.$emit('input', { selected: this.value.selected, open: '' })
       } else {
-        this.collapsed = name
+        this.$emit('input', { selected: this.value.selected, open: name })
       }
     }
   },

--- a/src/components/tree/CollapsibleTree.vue
+++ b/src/components/tree/CollapsibleTree.vue
@@ -19,16 +19,16 @@
               <collapse-tree-icon
                 v-if="hasChildren(parent)"
                 class="mr-2"
-                :state="parent.name == value.open"
+                :state="parent.name == opensection"
               />
               <span v-if="parent.count" class="badge badge-pill badge-light float-right align-self-center">{{parent.count}}</span>
             </div>
           </div>
         </li>
-        <block-expand :key="'b-'+ parent.name" :isExpanded="parent.name == value.open && hasChildren(parent)" class="list-group-item p-0" >
+        <block-expand :key="'b-'+ parent.name" :isExpanded="parent.name == opensection && hasChildren(parent)" class="list-group-item p-0" >
           <ul class="list-group list-group-flush">
             <li
-              :class="(value.selection===child.id)&&'active'"
+              :class="(selection===child.id)&&'active'"
               class="list-group-item list-group-item-outline-secondary list-group-item-action py-1 child-list"
               role="button"
               v-for="child in parent.children"
@@ -62,12 +62,16 @@ import BlockExpand from '../animations/BlockExpand.vue'
 export default Vue.extend({
   name: 'CollapsibleTree',
   props: {
-    value: {
-      type: Object,
+    selection: {
+      type: Number,
       required: true
     },
     structure: {
       type: Array,
+      required: true
+    },
+    opensection: {
+      type: String,
       required: true
     }
   },
@@ -78,13 +82,13 @@ export default Vue.extend({
   },
   methods: {
     selectElement (id) {
-      this.$emit('input', { selected: id, open: this.value.open })
+      this.$emit('updateselection', id)
     },
     toggleCollapse (name) {
-      if (this.value.open === name) {
-        this.$emit('input', { selected: this.value.selected, open: '' })
+      if (this.opensection === name) {
+        this.$emit('updateopensection', '')
       } else {
-        this.$emit('input', { selected: this.value.selected, open: name })
+        this.$emit('updateopensection', name)
       }
     }
   },

--- a/src/store/mutations.ts
+++ b/src/store/mutations.ts
@@ -42,6 +42,9 @@ export default {
   updateTreeSelection (state: ApplicationState, selection: number) {
     state.treeSelected = selection
   },
+  updateTreeOpenSection (state: ApplicationState, treeOpenSection: string) {
+    state.treeOpenSection = treeOpenSection
+  },
   updateSections (state: ApplicationState, sections: {[key:number]: Section}) {
     state.sections = sections
   },

--- a/src/views/TreeView.vue
+++ b/src/views/TreeView.vue
@@ -1,29 +1,37 @@
 <template>
   <div id="tree-view">
-    <collapsible-tree v-model="selection" :structure="treeStructure" />
+    <collapsible-tree
+      :selection="treeSelected"
+      :structure="treeStructure"
+      :opensection="treeOpenSection"
+      @updateselection="updateSelection"
+      @updateopensection="updateOpenSection" />
   </div>
 </template>
 
 <script>
 import Vue from 'vue'
 import CollapsibleTree from '../components/tree/CollapsibleTree.vue'
-import { mapGetters } from 'vuex'
+import { mapGetters, mapState } from 'vuex'
 
 export default Vue.extend({
   name: 'TreeView',
+  data: function () {
+    return {
+      selection: -1,
+      open: ''
+    }
+  },
   computed: {
     ...mapGetters(['treeStructure']),
-    selection: {
-      get () {
-        return {
-          selected: this.$store.state.treeSelected,
-          open: this.$store.state.treeOpenSection
-        }
-      },
-      set ({ selected, open }) {
-        this.$store.commit('updateTreeSelection', selected)
-        this.$store.commit('updateTreeOpenSection', open)
-      }
+    ...mapState(['treeSelected', 'treeOpenSection'])
+  },
+  methods: {
+    updateSelection (value) {
+      this.$store.commit('updateTreeSelection', value)
+    },
+    updateOpenSection (value) {
+      this.$store.commit('updateTreeOpenSection', value)
     }
   },
   created () {

--- a/src/views/TreeView.vue
+++ b/src/views/TreeView.vue
@@ -15,10 +15,14 @@ export default Vue.extend({
     ...mapGetters(['treeStructure']),
     selection: {
       get () {
-        return this.$store.state.treeSelected
+        return {
+          selected: this.$store.state.treeSelected,
+          open: this.$store.state.treeOpenSection
+        }
       },
-      set (value) {
-        this.$store.commit('updateTreeSelection', value)
+      set ({ selected, open }) {
+        this.$store.commit('updateTreeSelection', selected)
+        this.$store.commit('updateTreeOpenSection', open)
       }
     }
   },

--- a/tests/unit/components/tree/CollapsibleTree.spec.ts
+++ b/tests/unit/components/tree/CollapsibleTree.spec.ts
@@ -11,7 +11,8 @@ describe('CollapsibleTree.vue', () => {
         'font-awesome-icon': '<div/>'
       },
       propsData: {
-        value: -1,
+        opensection: '',
+        selection: -1,
         structure: [
           {
             name: 'test-parent',
@@ -34,17 +35,20 @@ describe('CollapsibleTree.vue', () => {
     expect(items.at(1).text()).toEqual('test-child')
   })
 
-  it('can close and hide children', () => {
-    expect(wrapper.find('.block-expander').classes('open')).toBeFalsy()
+  it('can open a section', () => {
     wrapper.find('[title="test-parent"]').trigger('click')
-    expect(wrapper.find('.block-expander').classes('open')).toBeTruthy()
-    wrapper.find('[title="test-parent"]').trigger('click')
-    expect(wrapper.find('.block-expander').classes('open')).toBeFalsy()
+    expect(wrapper.emitted().updateopensection).toEqual([['test-parent']])
   })
 
   it('can select child', () => {
     wrapper.find('[title="test-parent"]').trigger('click')
     wrapper.find('[title="test-child"]').trigger('click')
-    expect(wrapper.emitted().input[0]).toEqual([10])
+    expect(wrapper.emitted().updateselection).toEqual([[10]])
+  })
+
+  it('will close by selecting the same section', () => {
+    wrapper.setProps({ opensection: 'test-parent' })
+    wrapper.find('[title="test-parent"]').trigger('click')
+    expect(wrapper.emitted().updateopensection).toEqual([['']])
   })
 })

--- a/tests/unit/views/TreeView.spec.ts
+++ b/tests/unit/views/TreeView.spec.ts
@@ -14,6 +14,12 @@ describe('TreeView.vue', () => {
   let wrapper: Wrapper<Vue>
   let store: any
   let treeUpdate = jest.fn()
+  let treeOpenUpdate = jest.fn()
+  let actions = {
+    loadSections: jest.fn(),
+    loadSubSections: jest.fn(),
+    loadSectionTree: jest.fn()
+  }
 
   beforeEach(() => {
     store = new Vuex.Store({
@@ -29,16 +35,16 @@ describe('TreeView.vue', () => {
           ]
         }]
       },
-      actions: {
-        loadSections: jest.fn(),
-        loadSubSections: jest.fn(),
-        loadSectionTree: jest.fn()
+      state: {
+        treeSelected: -1,
+        treeOpenSection: ''
       },
+      actions,
       mutations: {
-        updateTreeSelection: treeUpdate
+        updateTreeSelection: treeUpdate,
+        updateTreeOpenSection: treeOpenUpdate
       }
     })
-    store.state.treeSelected = -1
 
     wrapper = mount(TreeView, {
       stubs: {
@@ -49,10 +55,17 @@ describe('TreeView.vue', () => {
     })
   })
 
-  it('Can select child item', () => {
+  it('Will load needed data', () => {
+    expect(actions.loadSections.mock.calls.length).toBe(1)
+    expect(actions.loadSubSections.mock.calls.length).toBe(1)
+    expect(actions.loadSectionTree.mock.calls.length).toBe(1)
+  })
+
+  it('Can update state', () => {
     expect(wrapper.exists()).toBeTruthy()
     wrapper.find('[title="parent"]').trigger('click')
+    expect(treeOpenUpdate.mock.calls).toEqual([[{ 'treeOpenSection': '', 'treeSelected': -1 }, 'parent']])
     wrapper.find('[title="child"]').trigger('click')
-    expect(treeUpdate.mock.calls).toEqual([ [ { treeSelected: -1 }, 10 ] ])
+    expect(treeUpdate.mock.calls).toEqual([[{ 'treeOpenSection': '', 'treeSelected': -1 }, 10]])
   })
 })


### PR DESCRIPTION
Tree component state of opened section is persisted via vuex
- Externalized opened section state to the TreeView.vue
- Bound the tree component to the store in TreeView.vue
- Redone the tests

#### Checklist
- [ ] Functionality works & meets specifications
- [ ] Code reviewed
- [ ] Code unit/integration/system tested
- [ ] User documentation updated
- [ ] Conventional commits (squash if needed)
- [ ] No warnings during install
- [ ] Updated javascript typing
