### PR TITLE
fix: Facet container partial visible

### DIFF
--- a/src/components/facets/FacetContainer.vue
+++ b/src/components/facets/FacetContainer.vue
@@ -65,7 +65,12 @@ export default Vue.extend({
   .facet-container {
     margin-bottom: 1rem;
   }
-
+  .block-expander{
+    margin-left: -1.5rem;
+    margin-right: -1.5rem;
+    padding-left: 1.5rem;
+    padding-right: 1.5rem;
+  }
   label {
     cursor: grab;
   }


### PR DESCRIPTION
Buttons edges, bars and popups have a little more room to the sides.
(Year of birth slider was partially hidden by `overflow:hidden`) 

#### Checklist
- [ ] Functionality works & meets specifications
- [ ] Code reviewed
- [ ] Code unit/integration/system tested
- [ ] User documentation updated
- [ ] Conventional commits (squash if needed)
- [ ] No warnings during install
- [ ] Updated javascript typing