### PR TITLE
Fix(BlockExpand) will now not force height

### DIFF
--- a/src/components/animations/BlockExpand.vue
+++ b/src/components/animations/BlockExpand.vue
@@ -53,10 +53,7 @@ export default Vue.extend({
 
 <style scoped lang="scss">
   .block-expander {
-    transition: height 0.5s ease-out;
-    &.no-animation{
-      transition: none !important;
-    }
+    transition: height 0.3s ease-out;
     overflow: hidden;
     height: 0;
   }

--- a/src/components/animations/BlockExpand.vue
+++ b/src/components/animations/BlockExpand.vue
@@ -17,18 +17,19 @@ export default Vue.extend({
   methods: {
     expand () {
       const height = this.$el.scrollHeight
+      const self = this
+      const test = function () {
+        self.$el.removeEventListener('transitionend', test)
+        self.$el.style.height = null
+      }
       this.$el.style.height = height + 'px'
+      this.$el.addEventListener('transitionend', test)
     },
     collapse () {
       const height = this.$el.scrollHeight
-      const elementTransition = this.$el.style.transition
-      this.$el.style.transition = ''
+      this.$el.style.height = height + 'px'
       requestAnimationFrame(() => {
-        this.$el.style.height = height + 'px'
-        this.$el.style.transition = elementTransition
-        requestAnimationFrame(() => {
-          this.$el.style.height = 0 + 'px'
-        })
+        this.$el.style.height = 0 + 'px'
       })
     }
   },
@@ -50,9 +51,12 @@ export default Vue.extend({
 })
 </script>
 
-<style scoped>
+<style scoped lang="scss">
   .block-expander {
-    transition: height 0.3s ease-out;
+    transition: height 0.5s ease-out;
+    &.no-animation{
+      transition: none !important;
+    }
     overflow: hidden;
     height: 0;
   }


### PR DESCRIPTION
Fixes: 
TreeView does not like it if we update the tree when it's expanded. Some of the nodes end up with weird height

Searching with tree open did not update height of element. Now the element is height: auto by default.

#### Checklist
- [ ] Functionality works & meets specifications
- [ ] Code reviewed
- [ ] Code unit/integration/system tested
- [ ] User documentation updated
- [ ] Conventional commits (squash if needed)
- [ ] No warnings during install
- [ ] Updated javascript typing