### PR TITLE
fix: Submit order error handling

### DIFF
--- a/src/store/actions.ts
+++ b/src/store/actions.ts
@@ -182,13 +182,13 @@ export default {
       options.body.set('orderNumber', generateOderId().toString())
       return api.post('/api/v1/lifelines_cart', options, true).then(() => {
         return 'success'
-      }, (error:any) => {
+      }, () => {
         // OrderNumber must be unique, just guess untill we find one
         if (reTryCount < 10) {
           reTryCount++
           return trySubmission()
         } else {
-          return Promise.reject({message: 'Could not submit order'})
+          return Promise.reject(new Error('Could not submit order'))
         }
       })
     }

--- a/src/store/actions.ts
+++ b/src/store/actions.ts
@@ -179,16 +179,16 @@ export default {
     let reTryCount = 0
 
     const trySubmission = () => {
-      reTryCount++
       options.body.set('orderNumber', generateOderId().toString())
       return api.post('/api/v1/lifelines_cart', options, true).then(() => {
         return 'success'
       }, (error:any) => {
         // OrderNumber must be unique, just guess untill we find one
         if (reTryCount < 10) {
+          reTryCount++
           return trySubmission()
         } else {
-          return error
+          return Promise.reject({message: 'Could not submit order'})
         }
       })
     }

--- a/tests/unit/store/actions.spec.ts
+++ b/tests/unit/store/actions.spec.ts
@@ -495,8 +495,9 @@ describe('actions', () => {
         done()
       })
 
-      it('should resturn error', () => {
-        expect(result).toEqual('error')
+      it('should retrun undefined and set the error msg', () => {
+        expect(result).toBeUndefined()
+        expect(commit).toHaveBeenCalledWith('setToast', { type: 'danger', message: 'Could not submit order' })
       })
     })
   })


### PR DESCRIPTION
- show msg in toast when submitting order fails

#### Checklist
- [ ] Functionality works & meets specifications
- [ ] Code reviewed
- [ ] Code unit/integration/system tested
- [ ] User documentation updated
- [ ] Conventional commits (squash if needed)
- [ ] No warnings during install
- [ ] Updated javascript typing
