### PR TITLE
fix: remove counts and selection dots from tree

### DIFF
--- a/src/components/tree/CollapsibleTree.vue
+++ b/src/components/tree/CollapsibleTree.vue
@@ -5,7 +5,6 @@
         <li
           :key="parent.name"
           class="list-group-item list-group-item-outline-secondary list-group-item-action text-truncate pr-3 py-2 parent-list"
-          :class="{ selecteditems: parent.count > 0 }"
           :title="parent.name"
           role="button"
           @click="toggleCollapse(parent.id)"
@@ -27,7 +26,7 @@
         <block-expand :key="'b-'+ parent.name" :isExpanded="parent.id == opensection && hasChildren(parent)" class="list-group-item p-0" >
           <ul class="list-group list-group-flush">
             <li
-              :class="{ active: (selection===child.id), selecteditems: child.count > 0 }"
+              :class="{ active: (selection===child.id) }"
               class="list-group-item list-group-item-outline-secondary list-group-item-action py-1 child-list"
               role="button"
               v-for="child in parent.children"
@@ -130,16 +129,6 @@ export default Vue.extend({
       transition: all 0.3s;
       transform: scale(2.5);
       background-color: transparent;
-    }
-    &.selecteditems {
-      position: relative;
-      &:before {
-        transform: scale(1);
-        background-color: $secondary;
-      }
-      &.active:before {
-        background-color: $light;
-      }
     }
   }
 </style>

--- a/src/store/actions.ts
+++ b/src/store/actions.ts
@@ -11,6 +11,7 @@ import Getters from '@/types/Getters'
 import { buildFormData, generateOrderNumber } from '@/services/orderService.ts'
 import FormField from '@/types/FormField'
 import { OrderState } from '@/types/Order'
+import { TreeParent } from '@/types/Tree'
 
 const buildPostOptions = (formData: any, formFields: FormField[]) => {
   return {
@@ -92,17 +93,17 @@ export default {
   loadSectionTree: tryAction(async ({ commit, state } : any) => {
     if (state.treeStructure.length === 0) {
       const response = await api.get('/api/v2/lifelines_tree?num=10000')
-      let structure: any = {}
+      let structure: {[id: number]: number[]} = {}
       response.items.map((item: any) => {
         if (item.section_id.id in structure) {
-          structure[item.section_id.id].push({ id: item.subsection_id.id, count: 0 })
+          structure[item.section_id.id].push(item.subsection_id.id)
         } else {
-          structure[item.section_id.id] = [{ id: item.subsection_id.id, count: 0 }]
+          structure[item.section_id.id] = [item.subsection_id.id]
         }
       })
-      let treeStructure: Array<Object> = []
+      let treeStructure: TreeParent[] = []
       for (let [key, value] of Object.entries(structure)) {
-        treeStructure.push({ key: key, list: value })
+        treeStructure.push({ key: (key as unknown) as number, list: value })
       }
       commit('updateSectionTree', treeStructure)
     }

--- a/src/store/getters.ts
+++ b/src/store/getters.ts
@@ -4,7 +4,7 @@ import { transformToRSQL } from '@molgenis/rsql'
 import Getters from '@/types/Getters'
 import Variant from '@/types/Variant'
 import { Variable, VariableWithVariants } from '@/types/Variable'
-import { TreeChild, TreeParentInternal } from '@/types/Tree'
+import { TreeParent } from '@/types/Tree'
 import Assessment from '@/types/Assessment'
 import { TreeNode } from '@/types/TreeNode'
 import { Section } from '@/types/Section'
@@ -118,24 +118,21 @@ export default {
       return total + item.filter(Boolean).length
     }, 0),
   treeStructure: (state: ApplicationState, getters: Getters) => {
-    const loadedSection:Boolean = Object.keys(state.sections).length > 0
-    const loadedSubSection:Boolean = state.subSectionList.length > 0
-    const loadedTreeStructure:Boolean = state.treeStructure.length > 0
+    const loadedSection: boolean = Object.keys(state.sections).length > 0
+    const loadedSubSection: boolean = state.subSectionList.length > 0
+    const loadedTreeStructure: boolean = state.treeStructure.length > 0
     if (loadedSection && loadedSubSection && loadedTreeStructure) {
       // return full tree
-      return state.treeStructure.map((item:TreeParentInternal) => {
+      return state.treeStructure.map((item:TreeParent) => {
         return {
           ...state.sections[item.key],
-          children: item.list.map((child:TreeChild) => {
+          children: item.list.map((id:number) => {
             return {
-              name: state.subSectionList[child.id],
-              count: child.count,
-              id: child.id
+              name: state.subSectionList[id],
+              id
             }
           })
         }
-      }).map((item:any) => { // Add count of all children to parent
-        return { ...item, count: item.children.reduce((total:number, child:TreeChild) => (total + child.count), 0) }
       })
     } else if (loadedSection) {
       // return temporary partial tree

--- a/src/store/mutations.ts
+++ b/src/store/mutations.ts
@@ -6,7 +6,7 @@ import Vue from 'vue'
 import GridSelection from '@/types/GridSelection'
 import Filter from '@/types/Filter'
 import { Section } from '@/types/Section.ts'
-import { TreeChild, TreeParentInternal } from '@/types/Tree'
+import { TreeParent } from '@/types/Tree'
 import { Order } from '@/types/Order'
 
 export default {
@@ -80,7 +80,7 @@ export default {
   updateSubSections (state: ApplicationState, subSections: string[]) {
     state.subSectionList = subSections
   },
-  updateSectionTree (state: ApplicationState, sections: TreeParentInternal[]) {
+  updateSectionTree (state: ApplicationState, sections: TreeParent[]) {
     state.treeStructure = sections
   },
   updateVariables (state: ApplicationState, variables: {[key:number]: Variable}) {
@@ -109,12 +109,6 @@ export default {
   },
   updateFilteredSubsections (state: ApplicationState, subsections: number[]) {
     state.filteredSubsections = subsections
-  },
-  setTreeCount (state: ApplicationState, count: number) {
-    const item:TreeChild|undefined = state.treeStructure[state.treeOpenPageSection - 1].list.find((item:TreeChild) => item.id === state.treeSelected)
-    if (item) {
-      item.count = count
-    }
   },
   toggleGridColumn ({ gridSelection, gridVariables }: {gridSelection: GridSelection, gridVariables: Variable[]}, { assessmentId } : {assessmentId: number}) {
     const allSelected = gridVariables.every((variable) => gridSelection.hasOwnProperty(variable.id) && gridSelection[variable.id].includes(assessmentId))

--- a/src/types/ApplicationState.ts
+++ b/src/types/ApplicationState.ts
@@ -5,7 +5,7 @@ import Assessment from '@/types/Assessment'
 import GridSelection from '@/types/GridSelection'
 import Filter from './Filter'
 import { Section } from '@/types/Section.ts'
-import { TreeParentInternal } from '@/types/Tree'
+import { TreeParent } from '@/types/Tree'
 import FormField from './FormField'
 import { Order } from './Order'
 
@@ -29,7 +29,7 @@ export default interface ApplicationState {
   ageGroupOptions: FacetOption[],
   ageAtOptions: FacetOption[],
   facetFilter: Filter,
-  treeStructure: TreeParentInternal[]
+  treeStructure: TreeParent[]
   gridVariables: VariableWithVariants[]
   variantCounts: Count[]
   participantCount: number | null

--- a/src/types/Tree.ts
+++ b/src/types/Tree.ts
@@ -1,15 +1,4 @@
-export interface TreeChild {
-  id: number
-  count: number
-}
-
 export interface TreeParent {
-  id: number
-  count: number
-  children: TreeChild[]
-}
-
-export interface TreeParentInternal {
   key: number
-  list: TreeChild[]
+  list: number[]
 }

--- a/tests/unit/store/getters.spec.ts
+++ b/tests/unit/store/getters.spec.ts
@@ -261,14 +261,14 @@ describe('getters', () => {
           }
         },
         subSectionList: ['sub-section1'],
-        treeStructure: [{ key: 1, list: [{ id: 0, count: 0 }] }]
+        treeStructure: [{ key: 1, list: [0] }]
       }
 
       const gettersParam: Getters = {
         ...emptyGetters
       }
       it('should return the complete tree structure', () => {
-        expect(getters.treeStructure(state, gettersParam)).toEqual([{ 'children': [{ 'count': 0, 'id': 0, 'name': 'sub-section1' }], 'count': 0, 'id': 1, 'name': 'section' }])
+        expect(getters.treeStructure(state, gettersParam)).toEqual([{ 'children': [{ 'id': 0, 'name': 'sub-section1' }], 'id': 1, 'name': 'section' }])
       })
     })
 

--- a/tests/unit/store/mutations.spec.ts
+++ b/tests/unit/store/mutations.spec.ts
@@ -254,25 +254,6 @@ describe('mutations', () => {
     })
   })
 
-  describe('setTreeCount', () => {
-    it('It can update the count ', () => {
-      const myState = {
-        ...state,
-        treeOpenPageSection: 1,
-        treeSelected: 2,
-        treeStructure: [{
-          key: 1,
-          list: [{
-            id: 2,
-            count: 0
-          }]
-        }]
-      }
-      mutations.setTreeCount(myState, 10)
-      expect(myState.treeStructure[0].list[0].count).toEqual(10)
-    })
-  })
-
   describe('toggleGridSelection', () => {
     it('selects if none selected', () => {
       const state = {


### PR DESCRIPTION
The relationship between variable selection and section selection
count is complicated.

You need to know the complete subsection<->variable details
if you want to relate selection to counts.
This is 17000 rows to fetch.
We choose not to.

#### Checklist
- [x] Functionality works & meets specifications
- [x] Code reviewed
- [x] Code unit/integration/system tested
- [x] User documentation updated
- [x] Conventional commits (squash if needed)
- [x] No warnings during install
- [x] Updated javascript typing
