### PR TITLE
fix: Closes #158 Set orderNumber to state before using it

### DIFF
--- a/src/store/actions.ts
+++ b/src/store/actions.ts
@@ -246,9 +246,9 @@ export default {
         return Promise.reject(new Error('Failed to submit order'))
       })
     }
-    dispatch('givePermissionToOrder')
     const newOrderResponse = await api.get(`/api/v2/lifelines_order/${orderNumber}`)
     commit('restoreOrderState', newOrderResponse)
+    dispatch('givePermissionToOrder')
     commit('setToast', { type: 'success', message: 'Submitted order with order number ' + orderNumber })
   }),
   load: tryAction(async ({ state, commit }: {state: ApplicationState, commit: any}, orderNumber: string) => {


### PR DESCRIPTION
First set the order to the state, then use the oderNumber to update the permissions

#### Checklist
- [x] Functionality works & meets specifications
- [x] Code reviewed
- [x] Code unit/integration/system tested
- [x] User documentation updated
- [x] Conventional commits (squash if needed)
- [x] No warnings during install
- [x] Updated javascript typing
