### PR TITLE
refactor: fix typings

### DIFF
--- a/src/store/getters.ts
+++ b/src/store/getters.ts
@@ -10,7 +10,7 @@ import { TreeNode } from '@/types/TreeNode'
 import { Section } from '@/types/Section'
 
 export default {
-  isSignedIn: (state: ApplicationState): boolean => !!state.context && !!state.context.context && state.context.context.authenticated,
+  isSignedIn: (state: ApplicationState): boolean => state.context.context && state.context.context.authenticated,
   variants: (state: ApplicationState): Variant[] =>
     state.gridVariables === null ? [] : state.gridVariables.reduce((result: Variant[], variable: VariableWithVariants): Variant[] =>
       variable.variants.reduce((accumulator: Variant[], variant: Variant) =>

--- a/src/store/store.ts
+++ b/src/store/store.ts
@@ -6,7 +6,6 @@ import getters from '@/store/getters'
 import mutations from '@/store/mutations'
 import ApplicationState from '@/types/ApplicationState'
 
-// @ts-ignore
 const { store: context } = require('@molgenis/molgenis-ui-context').default
 
 const packageJson = require('../../package.json')
@@ -14,8 +13,8 @@ Vue.use(Vuex)
 
 context.state.appVersion = packageJson.version
 
-export default new Vuex.Store<ApplicationState>({
-  state,
+export default new Vuex.Store({
+  state: state as ApplicationState,
   getters,
   mutations,
   actions,

--- a/src/types/ApplicationState.ts
+++ b/src/types/ApplicationState.ts
@@ -8,7 +8,7 @@ import { Section } from '@/types/Section.ts'
 import { TreeParent } from '@/types/Tree'
 import FormField from './FormField'
 import { Order } from './Order'
-import { ContextState } from '@molgenis/molgenis-ui-context/src/types'
+import { Context, ContextState } from '@molgenis/molgenis-ui-context/src/types'
 
 export type Toast = {
   type: 'danger' | 'success',
@@ -42,6 +42,11 @@ export interface AppState {
   orders: Order[] | null
 }
 
+// we start using the store only after the context is loaded
+interface LoadedContextState extends ContextState {
+    context: Context
+}
+
 export default interface ApplicationState extends AppState {
-  context?: ContextState
+  context: LoadedContextState
 }

--- a/tests/unit/fixtures/state.ts
+++ b/tests/unit/fixtures/state.ts
@@ -1,0 +1,68 @@
+import ApplicationState from '@/types/ApplicationState'
+
+import initialState from '@/store/state'
+
+const state: ApplicationState = {
+  ...initialState,
+  context: {
+    context: {
+      logoTopMaxHeight: 150,
+      navBarLogo: '/img/Logo_Blue_Small.png',
+      menu: {
+        id: 'main',
+        label: 'Home',
+        items: [
+          { type: 'plugin', id: 'home', label: 'Home' },
+          { type: 'plugin', id: 'app-molgenis-app-example', label: 'Example', params: '' },
+          { type: 'menu',
+            id: 'importdata',
+            label: 'Import data',
+            items: [
+              { type: 'plugin', id: 'one-click-importer', label: 'Quick data import' },
+              { type: 'plugin', id: 'importwizard', label: 'Advanced data import' }] },
+          { type: 'plugin', id: 'navigator', label: 'Navigator' },
+          { type: 'plugin', id: 'dataexplorer', label: 'Data Explorer' },
+          { type: 'menu',
+            id: 'dataintegration',
+            label: 'Data Integration',
+            items: [
+              { type: 'plugin', id: 'metadata-manager', label: 'Metadata Manager' },
+              { type: 'plugin', id: 'mappingservice', label: 'Mapping Service' },
+              { type: 'plugin', id: 'sorta', label: 'SORTA' },
+              { type: 'plugin', id: 'tagwizard', label: 'Tag Wizard' }] },
+          { type: 'menu',
+            id: 'plugins',
+            label: 'Plugins',
+            items: [
+              { type: 'plugin', id: 'searchAll', label: 'Search all data' },
+              { type: 'plugin', id: 'swagger', label: 'API documentation' },
+              { type: 'plugin', id: 'appmanager', label: 'App manager' },
+              { type: 'plugin', id: 'feedback', label: 'Feedback' },
+              { type: 'plugin', id: 'jobs', label: 'Job overview' },
+              { type: 'plugin', id: 'questionnaires', label: 'Questionnaires' },
+              { type: 'plugin', id: 'scripts', label: 'Scripts' }] },
+          { type: 'menu',
+            id: 'admin',
+            label: 'Admin',
+            items: [
+              { type: 'plugin', id: 'logmanager', label: 'Log manager' },
+              { type: 'plugin', id: 'menumanager', label: 'Menu Manager' },
+              { type: 'plugin', id: 'permissionmanager', label: 'Permission Manager' },
+              { type: 'plugin', id: 'scheduledjobs', label: 'Scheduled Jobs' },
+              { type: 'plugin', id: 'settings', label: 'Settings' },
+              { type: 'plugin', id: 'thememanager', label: 'Theme Manager' },
+              { type: 'plugin', id: 'usermanager', label: 'User Manager' },
+              { type: 'plugin', id: 'security-ui', label: 'Security Manager' }] },
+          { type: 'plugin', id: 'useraccount', label: 'Account' }] },
+      loginHref: '/login',
+      helpLink: { label: 'Help', href: 'https://molgenis.gitbooks.io/molgenis/content/' },
+      authenticated: false,
+      showCookieWall: false,
+      additionalMessage: 'Footerdefooter',
+      version: '8.3.0-SNAPSHOT',
+      buildDate: '2019-11-07 15:05 UTC'
+    }
+  }
+}
+
+export default state

--- a/tests/unit/store/actions.spec.ts
+++ b/tests/unit/store/actions.spec.ts
@@ -1,6 +1,6 @@
 import actions from '@/store/actions'
 import { Cart } from '@/types/Cart'
-import emptyState from '@/store/state'
+import emptyState from '../fixtures/state'
 import orders from '../fixtures/orders'
 
 // @ts-ignore

--- a/tests/unit/store/getters.spec.ts
+++ b/tests/unit/store/getters.spec.ts
@@ -1,5 +1,5 @@
 import getters from '@/store/getters'
-import emptyState from '@/store/state'
+import emptyState from '../fixtures/state'
 import Getters from '@/types/Getters'
 import ApplicationState from '@/types/ApplicationState'
 import Variant from '@/types/Variant'
@@ -53,9 +53,6 @@ describe('getters', () => {
   }
 
   describe('isSignedIn', () => {
-    it('is false when context is not loaded', () => {
-      expect(getters.isSignedIn({ ...emptyState, context: { context: null } })).toBe(false)
-    })
     it('is false when context is not authenticated', () => {
       expect(getters.isSignedIn({ ...emptyState, context: { context: { authenticated: false } } as any })).toBe(false)
     })

--- a/tests/unit/store/helpers.spec.ts
+++ b/tests/unit/store/helpers.spec.ts
@@ -1,6 +1,6 @@
 import { getErrorMessage, tryAction, toCart, fromCart } from '@/store/helpers'
 import Vue from 'vue'
-import emptyState from '@/store/state'
+import emptyState from '../fixtures/state'
 import { CartFilter, Cart } from '@/types/Cart'
 import Filter from '@/types/Filter'
 

--- a/tests/unit/store/mutations.spec.ts
+++ b/tests/unit/store/mutations.spec.ts
@@ -1,5 +1,5 @@
 import mutations from '@/store/mutations'
-import state from '@/store/state'
+import state from '../fixtures/state'
 import orders from '../fixtures/orders'
 import { OrderState } from '@/types/Order'
 

--- a/tests/unit/store/state.spec.ts
+++ b/tests/unit/store/state.spec.ts
@@ -1,4 +1,4 @@
-import state from '@/store/state'
+import state from '../fixtures/state'
 
 describe('state', () => {
   it('should contain the ordrFormFields', () => {

--- a/tests/unit/views/CountView.spec.ts
+++ b/tests/unit/views/CountView.spec.ts
@@ -1,7 +1,7 @@
 import { shallowMount, createLocalVue } from '@vue/test-utils'
 import CountView from '@/views/CountView.vue'
 import Vuex, { Store } from 'vuex'
-import state from '@/store/state'
+import state from '../fixtures/state'
 import getters from '@/store/getters'
 import mutations from '@/store/mutations'
 

--- a/tests/unit/views/MainView.spec.ts
+++ b/tests/unit/views/MainView.spec.ts
@@ -1,6 +1,6 @@
 import { shallowMount, createLocalVue } from '@vue/test-utils'
 import MainView from '@/views/MainView.vue'
-import state from '@/store/state'
+import state from '../fixtures/state'
 import Vuex from 'vuex'
 
 describe('MainView.vue', () => {

--- a/tests/unit/views/SidebarView.spec.ts
+++ b/tests/unit/views/SidebarView.spec.ts
@@ -1,6 +1,6 @@
 import { shallowMount, createLocalVue, Wrapper } from '@vue/test-utils'
 import SidebarView from '@/views/SidebarView.vue'
-import emptyState from '@/store/state'
+import emptyState from '../fixtures/state'
 import Vue from 'vue'
 import Vuex from 'vuex'
 import ApplicationState from '@/types/ApplicationState'


### PR DESCRIPTION
We only start using the store once the context is loaded.
Update typings to reflect this

The benefit is that the typescript checker will know that the context is always available and will not make you do lots of null checks.

#### Checklist
- [x] Functionality works & meets specifications
- [x] Code reviewed
- [x] Code unit/integration/system tested
- [x] User documentation updated
- [x] Conventional commits (squash if needed)
- [x] No warnings during install
- [x] Updated javascript typing
