### PR TITLE
fix: use min-width for tree-view(IE11)

### DIFF
--- a/src/views/TreeView.vue
+++ b/src/views/TreeView.vue
@@ -37,3 +37,10 @@ export default Vue.extend({
   components: { CollapsibleTree }
 })
 </script>
+
+<style lang="scss" scoped>
+  // Required for IE11
+  #tree-view {
+    min-width: 350px;
+  }
+</style>

--- a/src/views/TreeView.vue
+++ b/src/views/TreeView.vue
@@ -41,6 +41,6 @@ export default Vue.extend({
 <style lang="scss" scoped>
   // Required for IE11
   #tree-view {
-    min-width: 350px;
+    min-width: 20rem;
   }
 </style>


### PR DESCRIPTION
#### Checklist
- [x] Functionality works & meets specifications
- [x] Code reviewed
- [x] Code unit/integration/system tested
- [x] User documentation updated
- [x] Conventional commits (squash if needed)
- [x] No warnings during install
- [x] Updated javascript typing
