### PR TITLE
fix: retain cart permission for user

### DIFF
--- a/src/services/permissionService.ts
+++ b/src/services/permissionService.ts
@@ -1,11 +1,25 @@
 // @ts-ignore
 import api from '@molgenis/molgenis-api-client'
 
-export const setPermission = async (rowId: string, tableId: string, role: string, permission: string) => {
+export const setRolePermission = async (rowId: string, tableId: string, role: string, permission: string) => {
   const data = {
     objects: [{
       objectId: rowId,
       permissions: [{ role, permission }]
+    }]
+  }
+  const options = {
+    body: JSON.stringify(data)
+  }
+
+  return api.post(`/api/permissions/entity-${tableId}`, options)
+}
+
+export const setUserPermission = async (rowId: string, tableId: string, user: string, permission: string) => {
+  const data = {
+    objects: [{
+      objectId: rowId,
+      permissions: [{ user, permission }]
     }]
   }
   const options = {

--- a/src/store/actions.ts
+++ b/src/store/actions.ts
@@ -350,7 +350,7 @@ export default {
       setRolePermission(state.order.applicationForm.id, 'sys_FileMeta', 'LIFELINES_MANAGER', 'WRITE')
     }
   }),
-  fixUserPermission: tryAction(async ({ state, commit }: { state: ApplicationState, commit: any }) => {
+  fixUserPermission: tryAction(async ({ state }: { state: ApplicationState }) => {
     if (state.order.orderNumber === null || state.order.contents === null || state.order.user === null) {
       throw new Error('Can not set permission if orderNumber or contents or user is not set')
     }

--- a/src/store/actions.ts
+++ b/src/store/actions.ts
@@ -13,7 +13,7 @@ import { OrderState } from '@/types/Order'
 import moment from 'moment'
 import { TreeParent } from '@/types/Tree'
 import axios from 'axios'
-import { setPermission } from '@/services/permissionService'
+import { setRolePermission, setUserPermission } from '@/services/permissionService'
 // @ts-ignore
 import { encodeRsqlValue } from '@molgenis/rsql'
 
@@ -221,26 +221,43 @@ export default {
       commit('updateVariantCounts', variantCounts)
     }
   }),
-  save: tryAction(async ({ state, commit }: { state: ApplicationState, commit: any }) => {
+  save: tryAction(async ({ state, commit, dispatch }: { state: ApplicationState, commit: any, dispatch: any }) => {
     const formFields = [...state.orderFormFields, { id: 'contents', type: 'file' }]
-    const { context: { email, username } } = state.context
+    const { context } = state.context
     const cart = toCart(state)
-    const contents = cartToBlob(cart)
 
-    const formData = {
-      ...state.order,
+    const formData:any = {
+      name: state.order.name,
+      orderNumber: state.order.orderNumber,
+      projectNumber: state.order.projectNumber,
+      applicationForm: state.order.applicationForm,
       updateDate: moment().toISOString(),
-      email,
-      user: username,
-      contents
+      contents: cartToBlob(cart),
+      creationDate: state.order.creationDate,
+      submissionDate: state.order.submissionDate,
+      state: state.order.state
     }
 
     if (state.order.orderNumber) {
+      formData.user = state.order.user
+      formData.email = state.order.email
+
       await updateOrder(formData, formFields)
+
+      // Assume admin edits the user's order.
+      if (context.username !== state.order.user) {
+        const newOrderResponse = await api.get(`/api/v2/lifelines_order/${state.order.orderNumber}`)
+        commit('restoreOrderState', newOrderResponse)
+        await dispatch('fixUserPermission')
+      }
+
       successMessage(`Saved order with order number ${state.order.orderNumber}`, commit)
 
       return state.order.orderNumber
     } else {
+      formData.user = context.username
+      formData.email = context.email
+
       const creationDateField = { id: 'creationDate', type: 'date' }
       const orderNumber = await createOrder(formData, [...formFields, creationDateField]).catch(() => {
         return Promise.reject(new Error('Failed to create order'))
@@ -328,11 +345,28 @@ export default {
     if (state.order.orderNumber === null) {
       throw new Error('Can not set permission if orderNumber is not set')
     }
-    setPermission(state.order.orderNumber, 'lifelines_order', 'LIFELINES_MANAGER', 'WRITE')
+    setRolePermission(state.order.orderNumber, 'lifelines_order', 'LIFELINES_MANAGER', 'WRITE')
     if (state.order.applicationForm && state.order.applicationForm.id) {
-      setPermission(state.order.applicationForm.id, 'sys_FileMeta', 'LIFELINES_MANAGER', 'WRITE')
+      setRolePermission(state.order.applicationForm.id, 'sys_FileMeta', 'LIFELINES_MANAGER', 'WRITE')
     }
   }),
+  fixUserPermission: tryAction(async ({ state, commit }: { state: ApplicationState, commit: any }) => {
+    if (state.order.orderNumber === null || state.order.contents === null || state.order.user === null) {
+      throw new Error('Can not set permission if orderNumber or contents or user is not set')
+    }
+    // @ts-ignore
+    const results = [
+      setUserPermission(state.order.orderNumber, 'lifelines_order', state.order.user, 'WRITE'),
+      setUserPermission(state.order.contents.id, 'sys_FileMeta', state.order.user, 'WRITE')
+    ]
+
+    if (state.order.applicationForm) {
+      results.push(setUserPermission(state.order.applicationForm.id, 'sys_FileMeta', state.order.user, 'WRITE'))
+    }
+
+    await Promise.all(results)
+  }),
+
   sendSubmissionTrigger: async () => {
     return axios.post('/edge-server/trigger?type=submit').catch((err: any) => {
       console.log('Send submit trigger failed')

--- a/src/store/mutations.ts
+++ b/src/store/mutations.ts
@@ -46,13 +46,16 @@ export default {
   restoreOrderState (state: ApplicationState, loadOrderResponse: Order) {
     state.order = {
       orderNumber: loadOrderResponse.orderNumber,
+      email: loadOrderResponse.email,
       name: loadOrderResponse.name,
       projectNumber: loadOrderResponse.projectNumber,
       applicationForm: loadOrderResponse.applicationForm,
       state: loadOrderResponse.state,
       creationDate: loadOrderResponse.creationDate,
       updateDate: loadOrderResponse.updateDate,
-      submissionDate: loadOrderResponse.submissionDate
+      submissionDate: loadOrderResponse.submissionDate,
+      contents: loadOrderResponse.contents,
+      user: loadOrderResponse.user
     }
   },
   setOrders (state: ApplicationState, orders: Order[]) {

--- a/src/store/state.ts
+++ b/src/store/state.ts
@@ -11,7 +11,10 @@ const state: AppState = {
     submissionDate: null,
     creationDate: null,
     updateDate: null,
-    state: null
+    state: null,
+    contents: null,
+    email: null,
+    user: null
   },
   orderFormFields: [
     {

--- a/src/types/Order.ts
+++ b/src/types/Order.ts
@@ -20,4 +20,7 @@ export interface Order {
     state: OrderState | null
     creationDate: string | null
     updateDate: string | null
+    contents: File | null
+    user: string | null
+    email: string | null
 }

--- a/tests/unit/fixtures/orders.ts
+++ b/tests/unit/fixtures/orders.ts
@@ -8,7 +8,10 @@ const orders: Order[] = [{
   updateDate: null,
   projectNumber: null,
   applicationForm: null,
-  state: OrderState.Draft
+  state: OrderState.Draft,
+  contents: null,
+  email: null,
+  user: null
 }, {
   orderNumber: 'abcde',
   name: 'My draft order',
@@ -21,7 +24,10 @@ const orders: Order[] = [{
     id: 'aaaac3rcetmgfmudsodb3laaay',
     url: 'https://lifelines.test.molgenis.org/files/aaaac3rcetmgfmudsodb3laaay'
   },
-  state: OrderState.Submitted
+  state: OrderState.Submitted,
+  contents: null,
+  email: null,
+  user: null
 }]
 
 export default orders

--- a/tests/unit/services/permissionService.spec.ts
+++ b/tests/unit/services/permissionService.spec.ts
@@ -1,0 +1,49 @@
+// @ts-ignore
+import api from '@molgenis/molgenis-api-client'
+import { setRolePermission, setUserPermission } from '@/services/permissionService'
+
+describe('permission service', () => {
+  describe('setRolePermission', () => {
+    let permission:any
+
+    beforeEach(async (done) => {
+      api.post = jest.fn()
+      permission = await setRolePermission('rowId', 'tableId', 'role', 'READ')
+      done()
+    })
+
+    afterEach(() => {
+      api.post.mockReset()
+    })
+
+    it('sends request to server', () => {
+      expect(api.post).toHaveBeenCalledWith(
+        '/api/permissions/entity-tableId',
+        expect.objectContaining({
+          body: expect.any(String)
+        }))
+    })
+  })
+
+  describe('setUserPermission', () => {
+    let permission:any
+
+    beforeEach(async (done) => {
+      api.post = jest.fn()
+      permission = await setUserPermission('rowId', 'tableId', 'user', 'READ')
+      done()
+    })
+
+    afterEach(() => {
+      api.post.mockReset()
+    })
+
+    it('sends request to server', () => {
+      expect(api.post).toHaveBeenCalledWith(
+        '/api/permissions/entity-tableId',
+        expect.objectContaining({
+          body: expect.any(String)
+        }))
+    })
+  })
+})

--- a/tests/unit/store/actions.spec.ts
+++ b/tests/unit/store/actions.spec.ts
@@ -22,6 +22,27 @@ const cart: Cart = {
   }
 }
 
+function getApplicationState () {
+  const state: ApplicationState = {
+    ...emptyState,
+    order: {
+      orderNumber: '12345',
+      name: null,
+      projectNumber: null,
+      applicationForm: null,
+      state: OrderState.Draft,
+      submissionDate: 'submissionDate',
+      creationDate: 'creationDate',
+      updateDate: 'updateDate',
+      contents: null,
+      user: 'test',
+      email: 'test@molgenis.org'
+    }
+  }
+
+  return state
+}
+
 const mockResponses: { [key: string]: Object } = {
   '/api/v2/lifelines_order?num=10000': {
     items: orders
@@ -524,21 +545,10 @@ describe('actions', () => {
     describe('if orderNumber is set', () => {
       it('saves grid selection', async (done) => {
         const commit = jest.fn()
-        const state: ApplicationState = {
-          ...emptyState,
-          order: {
-            orderNumber: '12345',
-            name: null,
-            projectNumber: null,
-            applicationForm: null,
-            state: OrderState.Draft,
-            submissionDate: 'submissionDate',
-            creationDate: 'creationDate',
-            updateDate: 'updateDate'
-          }
-        }
+        const dispatch = jest.fn()
+        const state = getApplicationState()
         post.mockResolvedValue('success')
-        const response = await actions.save({ state, commit })
+        const response = await actions.save({ state, commit, dispatch })
         expect(commit).toHaveBeenCalledWith('setToast', { message: 'Saved order with order number 12345', textType: 'light', timeout: Vue.prototype.$global.toastTimeoutTime, title: 'Success', type: 'success' })
         expect(response).toBe('12345')
         expect(post).toHaveBeenCalledWith('/api/v1/lifelines_order/12345?_method=PUT', expect.anything(), true)
@@ -549,6 +559,8 @@ describe('actions', () => {
     describe('if orderNumber not set', () => {
       it('saves grid selection', async (done) => {
         const commit = jest.fn()
+        const dispatch = jest.fn()
+
         const state: ApplicationState = {
           ...emptyState,
           order: {
@@ -556,16 +568,20 @@ describe('actions', () => {
             name: null,
             projectNumber: null,
             applicationForm: null,
-            state: null,
-            submissionDate: null,
-            creationDate: null,
-            updateDate: null
+            state: OrderState.Draft,
+            submissionDate: 'submissionDate',
+            creationDate: 'creationDate',
+            updateDate: 'updateDate',
+            contents: null,
+            user: 'test',
+            email: 'test@molgenis.org'
           }
         }
+
         jest.spyOn(orderService, 'buildFormData').mockImplementation(() => new FormData())
         jest.spyOn(orderService, 'generateOrderNumber').mockImplementation(() => '12345')
         post.mockResolvedValue('success')
-        const response = await actions.save({ state, commit })
+        const response = await actions.save({ state, commit, dispatch })
         expect(commit).toHaveBeenCalledWith('setToast', { message: 'Saved order with order number 12345', textType: 'light', timeout: Vue.prototype.$global.toastTimeoutTime, title: 'Success', type: 'success' })
         expect(response).toBe('12345')
         expect(post).toHaveBeenCalledWith('/api/v1/lifelines_order', expect.anything(), true)
@@ -576,53 +592,29 @@ describe('actions', () => {
     describe('if applicationForm is a fileRef', () => {
       it('saves order', async (done) => {
         const commit = jest.fn()
-        const state: ApplicationState = {
-          ...emptyState,
-          order: {
-            orderNumber: '12345',
-            name: null,
-            projectNumber: null,
-            applicationForm: {
-              id: 'id',
-              url: 'url',
-              filename: 'my file'
-            },
-            state: null,
-            submissionDate: null,
-            creationDate: null,
-            updateDate: null
-          }
-        }
+        const dispatch = jest.fn()
+        const state = getApplicationState()
+
         jest.spyOn(orderService, 'buildFormData').mockImplementation(() => new FormData())
         post.mockResolvedValue('success')
-        await actions.save({ state, commit })
+        await actions.save({ state, commit, dispatch })
         expect(commit).toHaveBeenCalledWith('setToast', { message: 'Saved order with order number 12345', textType: 'light', timeout: Vue.prototype.$global.toastTimeoutTime, title: 'Success', type: 'success' })
         expect(post).toHaveBeenCalledWith('/api/v1/lifelines_order/12345?_method=PUT', expect.anything(), true)
         done()
       })
     })
 
-    describe('when the submission not succesfull', () => {
+    describe('when the submission not succesful', () => {
       let result: any
       let commit: any
-      let state: ApplicationState
+      const dispatch = jest.fn()
+
       beforeEach(async (done) => {
         commit = jest.fn()
-        state = {
-          ...emptyState,
-          order: {
-            orderNumber: null,
-            name: null,
-            projectNumber: null,
-            applicationForm: null,
-            state: OrderState.Draft,
-            submissionDate: 'submissionDate',
-            creationDate: 'creationDate',
-            updateDate: 'updateDate'
-          }
-        }
+
+        const state = getApplicationState()
         post.mockRejectedValue('error')
-        result = await actions.save({ commit, state })
+        result = await actions.save({ commit, state, dispatch })
         done()
       })
 
@@ -638,19 +630,7 @@ describe('actions', () => {
       it('submits the order', async (done) => {
         const commit = jest.fn()
         const dispatch = jest.fn()
-        const state: ApplicationState = {
-          ...emptyState,
-          order: {
-            orderNumber: '12345',
-            name: null,
-            projectNumber: null,
-            applicationForm: null,
-            state: OrderState.Draft,
-            submissionDate: 'submissionDate',
-            creationDate: 'creationDate',
-            updateDate: 'updateDate'
-          }
-        }
+        const state = getApplicationState()
         post.mockResolvedValue('success')
         await actions.submit({ state, commit, dispatch })
         expect(commit).toHaveBeenCalledWith('setToast', { message: 'Submitted order with order number 12345', textType: 'light', timeout: Vue.prototype.$global.toastTimeoutTime, title: 'Success', type: 'success' })
@@ -663,19 +643,8 @@ describe('actions', () => {
       it('submits the order', async (done) => {
         const commit = jest.fn()
         const dispatch = jest.fn()
-        const state: ApplicationState = {
-          ...emptyState,
-          order: {
-            orderNumber: null,
-            name: null,
-            projectNumber: null,
-            applicationForm: null,
-            state: OrderState.Draft,
-            submissionDate: 'submissionDate',
-            creationDate: 'creationDate',
-            updateDate: 'updateDate'
-          }
-        }
+        const state = getApplicationState()
+
         post.mockResolvedValue('success')
         await actions.submit({ state, commit, dispatch })
         expect(commit).toHaveBeenCalledWith('setToast', { message: 'Submitted order with order number 12345', textType: 'light', timeout: Vue.prototype.$global.toastTimeoutTime, title: 'Success', type: 'success' })
@@ -693,19 +662,8 @@ describe('actions', () => {
       beforeEach(async (done) => {
         commit = jest.fn()
         dispatch = jest.fn()
-        state = {
-          ...emptyState,
-          order: {
-            orderNumber: null,
-            name: null,
-            projectNumber: null,
-            applicationForm: null,
-            state: OrderState.Draft,
-            submissionDate: 'submissionDate',
-            creationDate: 'creationDate',
-            updateDate: 'updateDate'
-          }
-        }
+        const state = getApplicationState()
+
         post.mockRejectedValue('error')
         result = await actions.submit({ commit, state, dispatch })
         done()

--- a/tests/unit/store/mutations.spec.ts
+++ b/tests/unit/store/mutations.spec.ts
@@ -159,7 +159,10 @@ describe('mutations', () => {
         submissionDate: 'ignore',
         creationDate: 'ignore',
         updateDate: 'ignore',
-        state: OrderState.Draft
+        state: OrderState.Draft,
+        contents: null,
+        email: null,
+        user: null
       }
       mutations.setOrderDetails(baseAppState, order)
 
@@ -175,7 +178,10 @@ describe('mutations', () => {
         state: null,
         submissionDate: null,
         creationDate: null,
-        updateDate: null
+        updateDate: null,
+        contents: null,
+        email: null,
+        user: null
       })
     })
   })
@@ -197,7 +203,10 @@ describe('mutations', () => {
         submissionDate: 'edit',
         creationDate: 'creationDate',
         updateDate: 'updateDate',
-        state: OrderState.Draft
+        state: OrderState.Draft,
+        contents: null,
+        email: null,
+        user: null
       }
       mutations.restoreOrderState(baseAppState, response)
 
@@ -213,7 +222,10 @@ describe('mutations', () => {
         submissionDate: 'edit',
         creationDate: 'creationDate',
         updateDate: 'updateDate',
-        state: OrderState.Draft
+        state: OrderState.Draft,
+        contents: null,
+        email: null,
+        user: null
       })
     })
   })


### PR DESCRIPTION
Give back permissions to order creator, in case update
user is not the creator/manager. The following rights
are adjusted:
* Order
  * Cart data
  * Application form

#### Checklist
- [ ] Functionality works & meets specifications
- [ ] Code reviewed
- [ ] Code unit/integration/system tested
- [ ] User documentation updated
- [ ] Conventional commits (squash if needed)
- [ ] No warnings during install
- [ ] Updated javascript typing
