### PR TITLE
fix: order permissions

### DIFF
--- a/src/views/OrdersView.vue
+++ b/src/views/OrdersView.vue
@@ -17,6 +17,7 @@
             <th scope="col"></th>
             <th scope="col"></th>
             <th scope="col"></th>
+            <th v-if="hasManagerRole" scope="col"></th>
             <th v-if="hasManagerRole" scope="col">{{$t('lifelines-webshop-orders-col-header-email')}}</th>
             <th scope="col">{{$t('lifelines-webshop-orders-col-header-title')}}</th>
             <th scope="col">{{$t('lifelines-webshop-orders-col-header-sub-date')}}</th>
@@ -30,7 +31,7 @@
           <tr v-for="order in orders" :key="order.id">
             <td>
               <router-link
-                v-if="order.state === 'Draft'"
+                v-if="order.state === 'Draft' || hasManagerRole"
                 class="btn btn-secondary btn-sm"
                 :to="`/shop/${order.orderNumber}`">
                   <font-awesome-icon icon="edit" aria-label="edit"/>
@@ -43,15 +44,17 @@
             </td>
             <td>
               <router-link
-                v-if="order.state === 'Draft'"
+                v-if="order.state === 'Draft' || hasManagerRole"
                 :to="{ name: 'orderDelete', params: {orderNumber: order.orderNumber}}"
                 class="btn btn-danger btn-sm t-btn-order-delete">
               <font-awesome-icon icon="trash" aria-label="delete"/>
               </router-link>
+            </td>
+            <td v-if="hasManagerRole">
               <button
-              v-if="order.state === 'Submitted' && hasManagerRole"
-              @click="handleApproveOrder(order.orderNumber)"
-              class="btn btn-success">
+                v-if="order.state === 'Submitted'"
+                @click="handleApproveOrder(order.orderNumber)"
+                class="btn btn-success">
                 <span v-if="approvingOrder == order.orderNumber">
                   Approving
                 </span>

--- a/tests/unit/store/actions.spec.ts
+++ b/tests/unit/store/actions.spec.ts
@@ -13,12 +13,6 @@ import { OrderState } from '@/types/Order'
 import * as orderService from '@/services/orderService'
 import { setRolePermission, setUserPermission } from '@/services/permissionService'
 
-// @ts-ignore
-global.console = {
-  log: jest.fn(),
-  error: jest.fn()
-}
-
 const cart: Cart = {
   selection: [{
     assessment: '1A',
@@ -796,7 +790,7 @@ describe('actions', () => {
       state = {
         order: {
           orderNumber: '12345',
-          constents: { id: 'contents-id' },
+          contents: { id: 'contents-id' },
           applicationForm: {
             id: 'app-form'
           }
@@ -808,8 +802,8 @@ describe('actions', () => {
 
     it('should call permission service', () => {
       expect(setRolePermission).nthCalledWith(1, '12345', 'lifelines_order', 'LIFELINES_MANAGER', 'WRITE')
-      // expect(setRolePermission).nthCalledWith(2, 'contents-id', 'sys_FileMeta', 'LIFELINES_MANAGER', 'WRITE')
-      // expect(setRolePermission).nthCalledWith(3, 'app-form', 'sys_FileMeta', 'LIFELINES_MANAGER', 'WRITE')
+      expect(setRolePermission).nthCalledWith(2, 'contents-id', 'sys_FileMeta', 'LIFELINES_MANAGER', 'WRITE')
+      expect(setRolePermission).nthCalledWith(3, 'app-form', 'sys_FileMeta', 'LIFELINES_MANAGER', 'WRITE')
     })
   })
 
@@ -828,15 +822,23 @@ describe('actions', () => {
 
   describe('sendSubmissionTrigger error handling', () => {
     let mockPost = jest.fn()
+
     beforeEach(async (done) => {
+      console.log = jest.fn()
       mockPost.mockRejectedValue('my err')
       axios.post = mockPost
       await actions.sendSubmissionTrigger()
       done()
     })
+
     it('should send a trigger of type submit', () => {
       expect(console.log).toBeCalledWith('Send submit trigger failed')
       expect(console.log).toBeCalledWith('my err')
+    })
+
+    afterEach(() => {
+      // @ts-ignore
+      console.log.mockClear()
     })
   })
 })

--- a/tests/unit/store/helpers.spec.ts
+++ b/tests/unit/store/helpers.spec.ts
@@ -4,6 +4,12 @@ import emptyState from '../fixtures/state'
 import { CartFilter, Cart } from '@/types/Cart'
 import Filter from '@/types/Filter'
 
+// @ts-ignore
+global.console = {
+  log: jest.fn(),
+  error: jest.fn()
+}
+
 describe('store', () => {
   describe('helpers', () => {
     describe('getErrorMessage', () => {

--- a/tests/unit/views/__snapshots__/OrdersView.spec.ts.snap
+++ b/tests/unit/views/__snapshots__/OrdersView.spec.ts.snap
@@ -8,6 +8,7 @@ exports[`OrdersView.vue checks content of order tables 1`] = `
       <th scope="col"></th>
       <th scope="col"></th>
       <!---->
+      <!---->
       <th scope="col">lifelines-webshop-orders-col-header-title</th>
       <th scope="col">lifelines-webshop-orders-col-header-sub-date</th>
       <th scope="col">lifelines-webshop-orders-col-header-project</th>
@@ -30,8 +31,8 @@ exports[`OrdersView.vue checks content of order tables 1`] = `
         <router-link-stub to="[object Object]" tag="a" event="click" class="btn btn-danger btn-sm t-btn-order-delete">
           <font-awesome-icon-stub icon="trash" aria-label="delete"></font-awesome-icon-stub>
         </router-link-stub>
-        <!---->
       </td>
+      <!---->
       <!---->
       <td></td>
       <td></td>
@@ -51,8 +52,8 @@ exports[`OrdersView.vue checks content of order tables 1`] = `
         </button></td>
       <td>
         <!---->
-        <!---->
       </td>
+      <!---->
       <!---->
       <td>My draft order</td>
       <td></td>


### PR DESCRIPTION
- Give admin permission on cart contents file on submit
- Remove giving permission on oder back to user when admin saves order ( it's not needed and fails )
- When admin makes a copy have the creator ( shopper ) permission on the copy
- Always show edit button if user is admin
- Always shop delete button if user is admin


#### Checklist
- [ ] Functionality works & meets specifications
- [ ] Code reviewed
- [ ] Code unit/integration/system tested
- [ ] User documentation updated
- [ ] Conventional commits (squash if needed)
- [ ] No warnings during install
- [ ] Updated javascript typing
