### PR TITLE
chore: add sourcemap support for vue, ts & scss

### DIFF
--- a/vue.config.js
+++ b/vue.config.js
@@ -34,7 +34,7 @@ module.exports = {
 
       Using `source-map` mode comes with a performance hit.
       If needed, this mode can be overriden with:
-      DEVTOOL=cheap-module-eval-source-map yarn serv
+      DEVTOOL=cheap-module-eval-source-map yarn serve
       */
       config.devtool = process.env.DEVTOOL ? process.env.DEVTOOL : 'source-map'
       console.log(`Sourcemap mode: ${config.devtool}`)

--- a/vue.config.js
+++ b/vue.config.js
@@ -24,7 +24,20 @@ module.exports = {
     : '/',
   configureWebpack: config => {
     if (process.env.NODE_ENV !== 'production') {
-      config.devtool = 'source-map'
+      /*
+      Vue-cli's default is `cheap-module-eval-source-map`,
+      however breakpoints only work correctly using
+      full source-maps. See:
+
+       - https://github.com/vuejs/vue-cli/issues/1806
+       - https://webpack.js.org/configuration/devtool/
+
+      Using `source-map` mode comes with a performance hit.
+      If needed, this mode can be overriden with:
+      DEVTOOL=cheap-module-eval-source-map yarn serv
+      */
+      config.devtool = process.env.DEVTOOL ? process.env.DEVTOOL : 'source-map'
+      console.log(`Sourcemap mode: ${config.devtool}`)
     }
 
     config.plugins.push(

--- a/vue.config.js
+++ b/vue.config.js
@@ -23,6 +23,10 @@ module.exports = {
     ? pkgName + '/dist/'
     : '/',
   configureWebpack: config => {
+    if (process.env.NODE_ENV !== 'production') {
+      config.devtool = 'source-map'
+    }
+
     config.plugins.push(
       new BannerPlugin({
         banner: bannerText
@@ -37,7 +41,8 @@ module.exports = {
         @import "src/scss/mixins.scss";
         `
       }
-    }
+    },
+    sourceMap: process.env.NODE_ENV !== 'production'
   },
   devServer: {
     // In CI mode, Safari cannot contact "localhost", so as a workaround, run the dev server using the jenkins agent pod dns instead.


### PR DESCRIPTION
Test with:
/usr/bin/chromium %U --remote-debugging-port=9222

Set a breakpoint in vscode and start debugging. Breakpoints are now properly hit and stepping works as expected. Also, while inspecting styles in the browser, it will list the proper source.

#### Checklist
- [x] Functionality works & meets specifications
- [x] Code reviewed
- [x] Code unit/integration/system tested
- [x] User documentation updated
- [x] Conventional commits (squash if needed)
- [x] No warnings during install
- [x] Updated javascript typing
