### PR TITLE
feat: only hide cohort selection when user clicks on the button

### DIFF
--- a/src/views/SidebarView.vue
+++ b/src/views/SidebarView.vue
@@ -1,5 +1,5 @@
 <template>
-  <div id="sidebar-view" v-click-outside="hide" :class="{'hide-bar':!value}">
+  <div id="sidebar-view" :class="{'hide-bar':!value}">
     <div class="label" @click="toggleVisibility">
       {{$t('lifelines-webshop-sidebar-header')}}
       <font-awesome-icon icon="angle-double-down" class="ml-2"></font-awesome-icon>


### PR DESCRIPTION
#### Checklist
- [ ] Functionality works & meets specifications
- [ ] Code reviewed
- [ ] Code unit/integration/system tested
- [ ] User documentation updated
- [ ] Conventional commits (squash if needed)
- [ ] No warnings during install
- [ ] Updated javascript typing

testcase:

cohort selection doesn't close when clicking outside. Only on the [<<] button