### PR TITLE
fix: add definition_en & definition_nl to Variable definition

### DIFF
--- a/src/components/grid/GridInfoDialog.vue
+++ b/src/components/grid/GridInfoDialog.vue
@@ -17,13 +17,13 @@
           <p>
             <strong>Description (en):</strong>
             <br />
-            {{data.definition_en}}
-            <span v-if="!data.definition_en">No description found.</span>
+            {{data.definitionEn}}
+            <span v-if="!data.definitionEn">No description found.</span>
           </p>
-          <p v-if="data.definition_nl">
+          <p v-if="data.definitionNl">
             <strong>Description (nl):</strong>
             <br />
-            {{data.definition_nl}}
+            {{data.definitionNl}}
           </p>
           <p v-if="data.options.length > 0">
             <strong>Categorical values (en):</strong>

--- a/src/repository/VariableRepository.ts
+++ b/src/repository/VariableRepository.ts
@@ -38,6 +38,8 @@ const toVariable = (response: any):VariableWithVariants => {
       label_en: option.label_en
     })) : [],
     subvariableOf: response.subvariable_of ? response.subvariable_of : null,
-    subvariables: response.subvariables
+    subvariables: response.subvariables,
+    definitionEn: response.definition_en ? response.definition_en : '',
+    definitionNl: response.definition_nl ? response.definition_nl : ''
   }
 }

--- a/src/types/Variable.ts
+++ b/src/types/Variable.ts
@@ -5,6 +5,8 @@ export interface Variable {
   label: string
   subsections: number[]
   subvariableOf: Variable | null
+  definitionEn: string
+  definitionNl: string
 }
 
 export interface VariableWithVariants extends Variable {

--- a/tests/unit/repository/VariableRepository.spec.ts
+++ b/tests/unit/repository/VariableRepository.spec.ts
@@ -72,7 +72,9 @@ describe('VariableRepository', () => {
           name: '',
           options: [],
           variants: [],
-          subvariableOf: null
+          subvariableOf: null,
+          definitionEn: '',
+          definitionNl: ''
         })
       })
     })
@@ -88,7 +90,9 @@ describe('VariableRepository', () => {
             variants: [{ assessment_id: '1', id: 1 }],
             subvariable_of: 1,
             subsections: [1],
-            options: [{ label_en: 'foo', bar: 'bas' }]
+            options: [{ label_en: 'foo', bar: 'bas' }],
+            definitionEn: '',
+            definitionNl: ''
           }
         }] })
         result = await fetchVariables('subsection_id=1', 1)
@@ -103,7 +107,9 @@ describe('VariableRepository', () => {
           options: [{ label_en: 'foo' }],
           variants: [{ assessmentId: '1', id: 1 }],
           subsections: [1],
-          subvariableOf: 1
+          subvariableOf: 1,
+          definitionEn: '',
+          definitionNl: ''
         })
       })
     })

--- a/tests/unit/store/getters.spec.ts
+++ b/tests/unit/store/getters.spec.ts
@@ -45,7 +45,9 @@ describe('getters', () => {
     subsections: [1],
     subvariables: [],
     subvariableOf: null,
-    options: []
+    options: [],
+    definitionNl: '',
+    definitionEn: ''
   }
   const variable12: VariableWithVariants = {
     id: 12,
@@ -55,7 +57,9 @@ describe('getters', () => {
     subsections: [1, 2],
     subvariables: [],
     subvariableOf: null,
-    options: []
+    options: [],
+    definitionNl: '',
+    definitionEn: ''
   }
   const variable13: VariableWithVariants = {
     id: 13,
@@ -65,7 +69,9 @@ describe('getters', () => {
     subsections: [3],
     subvariables: [],
     subvariableOf: null,
-    options: []
+    options: [],
+    definitionNl: '',
+    definitionEn: ''
   }
 
   describe('cartTree', () => {

--- a/tests/unit/store/helpers.spec.ts
+++ b/tests/unit/store/helpers.spec.ts
@@ -108,8 +108,8 @@ describe('store', () => {
         expect(toCart({
           ...emptyState,
           variables: {
-            1: { id: 1, name: 'VAR1', label: 'variable 1', subsections: [1], subvariableOf: null },
-            2: { id: 2, name: 'VAR2', label: 'variable 2', subsections: [1], subvariableOf: null }
+            1: { id: 1, name: 'VAR1', label: 'variable 1', subsections: [1], subvariableOf: null, definitionEn: '', definitionNl: '' },
+            2: { id: 2, name: 'VAR2', label: 'variable 2', subsections: [1], subvariableOf: null, definitionEn: '', definitionNl: '' }
           },
           assessments: {
             1: { id: 1, name: '1A' },
@@ -153,8 +153,8 @@ describe('store', () => {
         }, {
           ...emptyState,
           variables: {
-            1: { id: 1, name: 'VAR1', label: 'variable 1', subsections: [1], subvariableOf: null },
-            2: { id: 2, name: 'VAR2', label: 'variable 2', subsections: [1], subvariableOf: null }
+            1: { id: 1, name: 'VAR1', label: 'variable 1', subsections: [1], subvariableOf: null, definitionEn: '', definitionNl: '' },
+            2: { id: 2, name: 'VAR2', label: 'variable 2', subsections: [1], subvariableOf: null, definitionEn: '', definitionNl: '' }
           },
           assessments: {
             1: { id: 1, name: '1A' },

--- a/tests/unit/store/mutations.spec.ts
+++ b/tests/unit/store/mutations.spec.ts
@@ -18,8 +18,9 @@ const gridVariables:VariableWithVariants[] = [
     subsections: [1],
     subvariableOf: null,
     subvariables: [],
-    options: []
-
+    options: [],
+    definitionNl: '',
+    definitionEn: ''
   },
   {
     id: 2,
@@ -32,7 +33,9 @@ const gridVariables:VariableWithVariants[] = [
     subsections: [1],
     subvariableOf: null,
     subvariables: [],
-    options: []
+    options: [],
+    definitionNl: '',
+    definitionEn: ''
   },
   {
     id: 3,
@@ -48,7 +51,9 @@ const gridVariables:VariableWithVariants[] = [
     subsections: [1],
     subvariableOf: null,
     subvariables: [],
-    options: []
+    options: [],
+    definitionNl: '',
+    definitionEn: ''
   }]
 
 describe('mutations', () => {
@@ -160,7 +165,9 @@ describe('mutations', () => {
           label: 'test label',
           name: 'test',
           subsections: [1, 2, 3, 4],
-          subvariableOf: null
+          subvariableOf: null,
+          definitionNl: '',
+          definitionEn: ''
         }
       })
       expect(baseAppState.variables).toEqual({
@@ -170,7 +177,9 @@ describe('mutations', () => {
           label: 'test label',
           name: 'test',
           subsections: [1, 2, 3, 4],
-          subvariableOf: null
+          subvariableOf: null,
+          definitionNl: '',
+          definitionEn: ''
         }
       })
     })


### PR DESCRIPTION
Closes #269

#### Checklist
- [x] Functionality works & meets specifications
- [x] Code reviewed
- [x] Code unit/integration/system tested
- [x] User documentation updated
- [x] Conventional commits (squash if needed)
- [x] No warnings during install
- [x] Updated javascript typing
