### PR TITLE
fix: fix 278 Grid header alignment is off

### DIFF
--- a/src/components/grid/GridComponent.vue
+++ b/src/components/grid/GridComponent.vue
@@ -81,7 +81,8 @@
                 @click="openInfoDialog(rowIndex)"
                 class="variable-column"
                 ref="variable"
-                v-b-popover.hover.left.html="popupBody(rowIndex)" :title="popupTitle(rowIndex)"
+                v-b-popover.hover.left.html="popupBody(rowIndex)"
+                :title="popupTitle(rowIndex)"
                 :class="{'selected-variable': rowIndex === selectedRowIndex }"
               >
                 <grid-titel-info
@@ -99,7 +100,7 @@
                   <font-awesome-icon icon="arrow-right" />
                 </button>
               </th>
-              <td class="cell" :key="colIndex" v-for="(count,colIndex) in row" >
+              <td class="cell" :key="colIndex" v-for="(count,colIndex) in row">
                 <button
                   :disabled="!isSignedIn"
                   :data-col="colIndex"
@@ -298,6 +299,15 @@ export default Vue.extend({
       if (table && header) {
         this.stickyTableHeader = table - header < 112 // 7rem @ 16px basesize
       }
+
+      // Update grid header offset to compansate for horizontal scrollbar
+      // This is needed due to use of absolute positioning used for foating header
+      if (this.$refs.gridheader && this.$refs.gridheader.className.indexOf('sticky') > -1) {
+        const left = window.pageXOffset || document.documentElement.scrollLeft
+        this.$refs.gridheader.style.marginLeft = '-' + left + 'px'
+      } else {
+        this.$refs.gridheader.style.marginLeft = '0px'
+      }
     },
     /**
      * Find largest variable width
@@ -451,10 +461,12 @@ table {
 }
 
 .sticky {
-  background: linear-gradient(180deg,
-  rgba(255, 255, 255, 1) 0%,
-  rgba(255, 255, 255, 0.9) 75%,
-  rgba(255, 255, 255, 0) 100%);
+  background: linear-gradient(
+    180deg,
+    rgba(255, 255, 255, 1) 0%,
+    rgba(255, 255, 255, 0.9) 75%,
+    rgba(255, 255, 255, 0) 100%
+  );
   pointer-events: none;
   position: fixed;
   top: 7rem;

--- a/src/components/grid/GridComponent.vue
+++ b/src/components/grid/GridComponent.vue
@@ -461,12 +461,10 @@ table {
 }
 
 .sticky {
-  background: linear-gradient(
-    180deg,
-    rgba(255, 255, 255, 1) 0%,
-    rgba(255, 255, 255, 0.9) 75%,
-    rgba(255, 255, 255, 0) 100%
-  );
+  background: linear-gradient(180deg,
+  rgba(255, 255, 255, 1) 0%,
+  rgba(255, 255, 255, 0.9) 75%,
+  rgba(255, 255, 255, 0) 100%);
   pointer-events: none;
   position: fixed;
   top: 7rem;

--- a/tests/unit/services/variableSetOrderService.spec.ts
+++ b/tests/unit/services/variableSetOrderService.spec.ts
@@ -14,7 +14,7 @@ describe('finalVariableSetSort', () => {
       subvariables: []
     }, {
       id: 2, // Parent variable
-      subvariables: [ { id: 3 }, { id: 4 }, { id: 5 } ],
+      subvariables: [ { id: 3 }, { id: 4 }, { id: 5 } ]
     }, {
       id: 6, // Normal variable
       subvariables: []


### PR DESCRIPTION
Closes: #278

When horizontal scrollbar is shown compansate for offset due to scroll bar
This is needed due to use of absolute positioning used for foating header

#### Checklist
- [ ] Functionality works & meets specifications
- [ ] Code reviewed
- [ ] Code unit/integration/system tested
- [ ] User documentation updated
- [ ] Conventional commits (squash if needed)
- [ ] No warnings during install
- [ ] Updated javascript typing
