### PR TITLE
fix: add missing context param to sendAproveTrigger action

### DIFF
--- a/src/store/actions.ts
+++ b/src/store/actions.ts
@@ -335,7 +335,7 @@ export default {
     await Promise.all(results)
   }),
 
-  sendApproveTrigger: tryAction(async (orderNumber: string) => {
+  sendApproveTrigger: tryAction(async (context:any, orderNumber: string) => {
     return axios.post(`/edge-server/approve?ordernumber=${orderNumber}`)
   })
 }

--- a/tests/unit/store/actions.spec.ts
+++ b/tests/unit/store/actions.spec.ts
@@ -897,7 +897,7 @@ describe('actions', () => {
       axios.post.mockResolvedValueOnce(() => Promise.resolve())
     })
     it('should send the port to the edge server', async (done) => {
-      await actions.sendApproveTrigger('my-order-nr')
+      await actions.sendApproveTrigger({}, 'my-order-nr')
       expect(axios.post).toHaveBeenCalledWith('/edge-server/approve?ordernumber=my-order-nr')
       done()
     })


### PR DESCRIPTION
#### Checklist
- [ ] Functionality works & meets specifications
- [ ] Code reviewed
- [ ] Code unit/integration/system tested
- [ ] User documentation updated
- [ ] Conventional commits (squash if needed)
- [ ] No warnings during install
- [ ] Updated javascript typing
