### PR TITLE
fix: Fix header position for collapse vars

### DIFF
--- a/src/components/grid/GridComponent.vue
+++ b/src/components/grid/GridComponent.vue
@@ -226,7 +226,7 @@ export default Vue.extend({
         this.openVariableSets.includes(variable.id)
       )
     },
-    variableSetClickHandler (variable) {
+    async variableSetClickHandler (variable) {
       if (variable.subvariables && variable.subvariables.length > 0) {
         if (this.variableSetIsOpen(variable)) {
           this.openVariableSets = this.openVariableSets.filter(
@@ -235,6 +235,9 @@ export default Vue.extend({
         } else {
           this.openVariableSets.push(variable.id)
         }
+        // Ajust the header for collapesed variables after layout is recalculated
+        await this.$nextTick()
+        this.setGridHeaderSpacer()
       }
     },
     isVisibleVariable (variable) {


### PR DESCRIPTION
Closes #300 

- call recalculate offset of header after collapse open/close

#### Checklist
- [ ] Functionality works & meets specifications
- [ ] Code reviewed
- [ ] Code unit/integration/system tested
- [ ] User documentation updated
- [ ] Conventional commits (squash if needed)
- [ ] No warnings during install
- [ ] Updated javascript typing
