### PR TITLE
fix: use trailing slash on vuepdf endpoint

### DIFF
--- a/src/views/OrdersView.vue
+++ b/src/views/OrdersView.vue
@@ -332,7 +332,7 @@ export default Vue.extend({
       }
 
       try {
-        const res = await axios.post('/vuepdf', { component: 'orders', state }, { responseType: 'blob' })
+        const res = await axios.post('/vuepdf/', { component: 'orders', state }, { responseType: 'blob' })
         // We could have used URL.createObjectURL manually, but
         // this library takes care of IE/Safari edge cases as well.
         const fileName = `${order.name ? order.name : `order-${order.orderNumber}`}.pdf`


### PR DESCRIPTION
#### Checklist
- [ ] Functionality works & meets specifications
- [ ] Code reviewed
- [ ] Code unit/integration/system tested
- [ ] User documentation updated
- [ ] Conventional commits (squash if needed)
- [ ] No warnings during install
- [ ] Updated javascript typing
