### PR TITLE
fix: 314 error during approve

### DIFF
--- a/src/store/actions.ts
+++ b/src/store/actions.ts
@@ -56,7 +56,7 @@ const createOrder = async (formData: any, formFields: FormField[]) => {
   return trySubmission(10)
 }
 
-const loadOrder = async ({ state, commit }: { state: ApplicationState, commit: any }, orderNumber: string) => {
+const loadOrder = async ({ commit }: { commit: any }, orderNumber: string) => {
   const response = await api.get(`/api/v2/lifelines_order/${orderNumber}`)
   commit('restoreOrderState', response)
   return response
@@ -254,7 +254,7 @@ export default {
     successMessage(`Submitted order with order number ${orderNumber}`, commit)
   }),
   loadOrderAndCart: tryAction(async ({ state, commit }: { state: ApplicationState, commit: any }, orderNumber: string) => {
-    const response = await loadOrder({ state, commit }, orderNumber)
+    const response = await loadOrder({ commit }, orderNumber)
     const cart: Cart = await api.get(`/files/${response.contents.id}`)
     const { facetFilter, gridSelection } = fromCart(cart, state)
     commit('updateFacetFilter', facetFilter)
@@ -288,8 +288,8 @@ export default {
       processBatch(batchResp)
     }
   },
-  loadOrder: tryAction(async ({ state, commit }: { state: ApplicationState, commit: any }, orderNumber: string) => {
-    return loadOrder({ state, commit }, orderNumber)
+  loadOrder: tryAction(async ({ commit }: { commit: any }, orderNumber: string) => {
+    return loadOrder({ commit }, orderNumber)
   }),
   copyOrder: tryAction(async ({ state, commit }: { state: ApplicationState, commit: any }, sourceOrderNumber: string) => {
     // Fetch source data

--- a/src/types/Order.ts
+++ b/src/types/Order.ts
@@ -5,7 +5,7 @@ export enum OrderState {
     Draft = 'Draft'
 }
 
-export interface File {
+export interface MolgenisFile {
     id: string
     filename: string
     url: string
@@ -16,11 +16,11 @@ export interface Order {
     name: string | null
     submissionDate: string | null
     projectNumber: string | null
-    applicationForm: File | null
+    applicationForm: MolgenisFile | File | null
     state: OrderState | null
     creationDate: string | null
     updateDate: string | null
-    contents: File | null
+    contents: MolgenisFile | File | null
     user: string | null
     email: string | null
 }

--- a/src/types/Order.ts
+++ b/src/types/Order.ts
@@ -16,11 +16,11 @@ export interface Order {
     name: string | null
     submissionDate: string | null
     projectNumber: string | null
-    applicationForm: MolgenisFile | File | null
+    applicationForm: MolgenisFile | null
     state: OrderState | null
     creationDate: string | null
     updateDate: string | null
-    contents: MolgenisFile | File | null
+    contents: MolgenisFile | null
     user: string | null
     email: string | null
 }

--- a/tests/unit/store/actions.spec.ts
+++ b/tests/unit/store/actions.spec.ts
@@ -746,6 +746,7 @@ describe('actions', () => {
         const dispatch = jest.fn()
         let state = getApplicationState()
         let applicationForm = new File(['foobar'], 'my-file-name')
+        // @ts-ignore
         state.order.applicationForm = applicationForm
         state.order.orderNumber = 'with-app-form'
 

--- a/tests/unit/store/actions.spec.ts
+++ b/tests/unit/store/actions.spec.ts
@@ -673,6 +673,17 @@ describe('actions', () => {
     })
   })
 
+  describe('loadOrder', () => {
+    it('should fetch the order details', async (done) => {
+      const commit = jest.fn()
+      const dispatch = jest.fn()
+      const state = getApplicationState()
+      await actions.loadOrder({ state, commit, dispatch }, 'fghij')
+      expect(commit).toHaveBeenCalledWith('restoreOrderState', { contents: { id: 'xxyyzz' } })
+      done()
+    })
+  })
+
   describe('save', () => {
     describe('if orderNumber is set', () => {
       it('saves grid selection', async (done) => {

--- a/tests/unit/store/actions.spec.ts
+++ b/tests/unit/store/actions.spec.ts
@@ -134,6 +134,13 @@ const mockResponses: { [key: string]: Object } = {
       id: 'bla'
     }
   },
+  '/api/v2/lifelines_order/with-app-form': {
+    contents: {
+      id: 'with-app-form'
+    },
+    user: 'with-app-form-user',
+    applicationForm: { id: 'applicationForm-id' }
+  },
   '/files/xxyyzz': cart,
   '/files/dm_test': cart,
   '/api/v2/lifelines_section?num=10000': {
@@ -715,7 +722,9 @@ describe('actions', () => {
     })
 
     describe('if applicationForm is a fileRef', () => {
-      it('saves order', async (done) => {
+      it('saves order and set content perm to order user', async (done) => {
+        // @ts-ignore
+        setUserPermission.mockReset()
         const commit = jest.fn()
         const dispatch = jest.fn()
         const state = getApplicationState()
@@ -725,6 +734,28 @@ describe('actions', () => {
         await actions.save({ state, commit, dispatch })
         expect(commit).toHaveBeenCalledWith('setToast', { message: 'Saved order with order number 12345', textType: 'light', timeout: Vue.prototype.$global.toastTimeoutTime, title: 'Success', type: 'success' })
         expect(post).toHaveBeenCalledWith('/api/v1/lifelines_order/12345?_method=PUT', expect.anything(), true)
+        // set user permission should be called only once as no application form permission should be set
+        expect(setUserPermission).toHaveBeenCalledTimes(1)
+        done()
+      })
+    })
+
+    describe('if applicationForm is file', () => {
+      it('saves order give set applicationForm permission to order user', async (done) => {
+        const commit = jest.fn()
+        const dispatch = jest.fn()
+        let state = getApplicationState()
+        let applicationForm = new File(['foobar'], 'my-file-name')
+        state.order.applicationForm = applicationForm
+        state.order.orderNumber = 'with-app-form'
+
+        let formData:any = new FormData()
+        formData.applicationForm = applicationForm
+        jest.spyOn(orderService, 'buildFormData').mockImplementation(() => formData)
+        post.mockResolvedValue('success')
+        await actions.save({ state, commit, dispatch })
+        expect(setUserPermission).toHaveBeenCalledWith('with-app-form', 'sys_FileMeta', 'with-app-form-user', 'WRITE')
+        expect(setUserPermission).toHaveBeenCalledWith('applicationForm-id', 'sys_FileMeta', 'with-app-form-user', 'WRITE')
         done()
       })
     })
@@ -816,56 +847,6 @@ describe('actions', () => {
     })
   })
 
-  describe('fixUserPermission', () => {
-    describe('state does not contain required parameters', () => {
-      let state: any
-      let commit = jest.fn()
-      beforeEach(() => {
-        state = {
-          order: {
-            orderNumber: null
-          }
-        }
-      })
-
-      it('throws an error', async (done) => {
-        await actions.fixUserPermission({ commit, state })
-        expect(commit).toHaveBeenCalledWith('setToast', expect.objectContaining({
-          message: 'Can not set permission if orderNumber or contents or user is not set'
-        }))
-        done()
-      })
-    })
-
-    describe('state contains required parameters', () => {
-      let state: any
-      let commit = jest.fn()
-
-      beforeEach(async (done) => {
-        state = {
-          order: {
-            applicationForm: { id: 'applicationForm' },
-            orderNumber: '12345',
-            contents: { id: 'contents' },
-            user: 'user'
-          }
-        }
-
-        await actions.fixUserPermission({ commit, state })
-        done()
-      })
-
-      afterEach(() => {
-        jest.resetAllMocks()
-      })
-
-      it('calls setUserPermission', () => {
-        expect(setUserPermission).toHaveBeenCalledWith('contents', 'sys_FileMeta', 'user', 'WRITE')
-        expect(setUserPermission).toHaveBeenCalledWith('applicationForm', 'sys_FileMeta', 'user', 'WRITE')
-      })
-    })
-  })
-
   describe('givePermissionToOrder with missing orderNumber', () => {
     let state: any
     beforeEach(async (done) => {
@@ -886,6 +867,8 @@ describe('actions', () => {
   describe('givePermissionToOrder with file attached', () => {
     let state: any
     beforeEach(async (done) => {
+      // @ts-ignore
+      setRolePermission.mockReset()
       state = {
         order: {
           orderNumber: '12345',


### PR DESCRIPTION
Closes #314

When a order is saved a new cart row is created
When the admin saves a order the order user should get permission on the cart
When the admin saves a order with file the user should also get permission on the file
When the admin save a order without file ( like approve ) the permission call for the file should not be made

#### Checklist
- [ ] Functionality works & meets specifications
- [ ] Code reviewed
- [ ] Code unit/integration/system tested
- [ ] User documentation updated
- [ ] Conventional commits (squash if needed)
- [ ] No warnings during install
- [ ] Updated javascript typing
