### PR TITLE
fix: #329 Cannot view old app version via browser url

### DIFF
--- a/package.json
+++ b/package.json
@@ -16,7 +16,8 @@
     "test:e2e": "vue-cli-service test:e2e",
     "test:unit": "vue-cli-service test:unit",
     "test:update-snapshot": "jest --updateSnapshot",
-    "test:watch": "jest --watchAll"
+    "test:watch": "jest --watchAll",
+    "postversion": "vue-cli-service build"
   },
   "files": [
     "dist",

--- a/vue.config.js
+++ b/vue.config.js
@@ -21,7 +21,7 @@ const config = require('rc')('lifelines', {
 
 module.exports = {
   outputDir: 'dist',
-  publicPath: process.env.NODE_ENV === 'production' ? pkgName + `${pkgName}/dist/${pkgVersion}` : '/',
+  publicPath: process.env.NODE_ENV === 'production' ? `/${pkgName}@${pkgVersion}/dist/` : '/',
   configureWebpack: config => {
     if (process.env.NODE_ENV !== 'production') {
       /*

--- a/vue.config.js
+++ b/vue.config.js
@@ -21,9 +21,7 @@ const config = require('rc')('lifelines', {
 
 module.exports = {
   outputDir: 'dist',
-  publicPath: process.env.NODE_ENV === 'production'
-    ? pkgName + '/dist/'
-    : '/',
+  publicPath: process.env.NODE_ENV === 'production' ? pkgName + `${pkgName}/dist/${pkgVersion}` : '/',
   configureWebpack: config => {
     if (process.env.NODE_ENV !== 'production') {
       /*


### PR DESCRIPTION
Closes #329
Closes #330
Closes #331

- Add version to build path
- Call build script in npm post version hook to use correct version number

#### Checklist
- [x] Functionality works & meets specifications
- [x] Code reviewed
- [x] Code unit/integration/system tested
-  User documentation updated
- [x] Conventional commits (squash if needed)
- [x] No warnings during install
-  Updated javascript typing
