### PR TITLE
fix: hover above instead of left

### DIFF
--- a/src/components/grid/GridComponent.vue
+++ b/src/components/grid/GridComponent.vue
@@ -86,7 +86,7 @@
                 <th
                   class="variable-column"
                   ref="variable"
-                  v-b-popover.hover.left.html="popupBody(rowIndex)"
+                  v-b-popover.hover.top.html="popupBody(rowIndex)"
                   :title="popupTitle(rowIndex)"
                   :class="{'selected-variable': rowIndex === selectedRowIndex }"
                 >


### PR DESCRIPTION
Improve UX, do not let popover cover the 'plus' icon

#### Checklist
- [ ] Functionality works & meets specifications
- [ ] Code reviewed
- [ ] Code unit/integration/system tested
- [ ] User documentation updated
- [ ] Conventional commits (squash if needed)
- [ ] No warnings during install
- [ ] Updated javascript typing
