### PR TITLE
fix: loading indicator is removed if query is outdated by other query

### DIFF
--- a/src/store/actions.ts
+++ b/src/store/actions.ts
@@ -141,8 +141,8 @@ export default {
     if (searchTermQuery === getters.searchTermQuery) {
       const sortedGridVariables = finalVariableSetSort(variables)
       commit('updateGridVariables', sortedGridVariables)
+      state.isSearching = false
     }
-    state.isSearching = false
   }),
   loadParticipantCount: tryAction(async ({ commit, getters }: any) => {
     commit('updateParticipantCount', null)


### PR DESCRIPTION
Only remove the loading indicator when search has completed
Search may be completed by a different request then the one that set up the indicator

#### Checklist
- [ ] Functionality works & meets specifications
- [ ] Code reviewed
- [ ] Code unit/integration/system tested
- [ ] User documentation updated
- [ ] Conventional commits (squash if needed)
- [ ] No warnings during install
- [ ] Updated javascript typing
