### PR TITLE
fix: loading indicator is removed if query is outdated by other query

### DIFF
--- a/src/store/actions.ts
+++ b/src/store/actions.ts
@@ -133,11 +133,15 @@ export default {
     const searchTermQuery = getters.searchTermQuery
 
     if (!searchTermQuery) {
+      state.isSearching = false
       return
     }
     state.isSearching = true
 
-    const variables = await fetchVariables(searchTermQuery, state.treeSelected)
+    const variables = await fetchVariables(searchTermQuery, state.treeSelected).catch(() => {
+      state.isSearching = false
+      throw new Error('Failed to fetch variables')
+    })
     if (searchTermQuery === getters.searchTermQuery) {
       const sortedGridVariables = finalVariableSetSort(variables)
       commit('updateGridVariables', sortedGridVariables)

--- a/src/store/actions.ts
+++ b/src/store/actions.ts
@@ -141,8 +141,8 @@ export default {
     if (searchTermQuery === getters.searchTermQuery) {
       const sortedGridVariables = finalVariableSetSort(variables)
       commit('updateGridVariables', sortedGridVariables)
+      state.isSearching = false
     }
-    state.isSearching = false
   }),
   loadParticipantCount: tryAction(async ({ commit, getters }: any) => {
     commit('updateParticipantCount', null)

--- a/tests/unit/store/actions.spec.ts
+++ b/tests/unit/store/actions.spec.ts
@@ -449,7 +449,8 @@ describe('actions', () => {
         commit = jest.fn()
         await actions.loadGridVariables({
           getters: { searchTermQuery: '' },
-          commit
+          commit,
+          state: { isSearching: true }
         })
         done()
       })

--- a/tests/unit/store/actions.spec.ts
+++ b/tests/unit/store/actions.spec.ts
@@ -513,6 +513,26 @@ describe('actions', () => {
         expect(commit).not.toHaveBeenCalledWith('updateGridVariables', [{ foo: 'bar' }])
       })
     })
+
+    describe('when variable fetch fails ', () => {
+      let commit: any
+      let state: any = {}
+
+      beforeEach(async (done) => {
+        commit = jest.fn()
+        const getters = { searchTermQuery: 'searchTermQuery' }
+        state.isSearching = true
+        // @ts-ignore
+        fetchVariables.mockRejectedValueOnce()
+        await actions.loadGridVariables({ getters, commit, state })
+        done()
+      })
+
+      it('should throw an error', () => {
+        expect(commit).toHaveBeenCalledWith('setToast', expect.objectContaining({ message: 'Failed to fetch variables' }))
+        expect(state.isSearching).toEqual(false)
+      })
+    })
   })
 
   describe('loadVariables', () => {


### PR DESCRIPTION
Only remove the loading indicator when search has completed
Search may be completed by a different request then the one that set up the indicator

#### Checklist
- [ ] Functionality works & meets specifications
- [ ] Code reviewed
- [ ] Code unit/integration/system tested
- [ ] User documentation updated
- [ ] Conventional commits (squash if needed)
- [ ] No warnings during install
- [ ] Updated javascript typing
