### PR TITLE
fix: fix cart variable  order

### DIFF
--- a/tests/unit/services/variableSetOrderService.spec.ts
+++ b/tests/unit/services/variableSetOrderService.spec.ts
@@ -1,4 +1,4 @@
-import { finalVariableSetSort } from '@/services/variableSetOrderService'
+import { finalVariableSetSort, sortAlphabetically } from '@/services/variableSetOrderService'
 
 describe('finalVariableSetSort', () => {
   // finalVariableSetSort takes a set of data and sorts so that subvariable are always after the parent variable
@@ -64,5 +64,24 @@ describe('finalVariableSetSort', () => {
       subvariables: []
     }]
     expect(finalVariableSetSort(data)).toEqual(out)
+  })
+
+  describe('sortAlphabetically', () => {
+    it('should sort the varaibles alphabetically by name prop', () => {
+      const varaibles: any = [
+        { name: 'z' },
+        { name: 'A' },
+        { name: 'b' }
+      ]
+      varaibles.sort(sortAlphabetically)
+
+      expect(varaibles).toEqual(
+        [
+          { name: 'A' },
+          { name: 'b' },
+          { name: 'z' }
+        ]
+      )
+    })
   })
 })


### PR DESCRIPTION
Trigger release off previous commit fix: cart variable order sorting

- Remove sub variable indicator from cart view
- Sort variables and sub variables alphabetically

#### Checklist
- [ ] Functionality works & meets specifications
- [ ] Code reviewed
- [ ] Code unit/integration/system tested
- [ ] User documentation updated
- [ ] Conventional commits (squash if needed)
- [ ] No warnings during install
- [ ] Updated javascript typing
