### PR TITLE
feat: #7702 hide empty rows ( due to assessment filter )

### DIFF
--- a/src/store/getters.ts
+++ b/src/store/getters.ts
@@ -7,6 +7,7 @@ import { VariableWithVariants } from '@/types/Variable'
 import CartSection from '@/types/CartSection'
 import 'core-js/fn/array/flat-map'
 import transforms from './transforms'
+import Assessment from '@/types/Assessment'
 
 export default {
   isSignedIn: (state: ApplicationState): boolean => state.context.context && state.context.context.authenticated,
@@ -104,7 +105,7 @@ export default {
     return transforms.gridRows(state.gridVariables, getters.gridColumns, state.variantCounts, getters.findZeroRowsAndCols, state.facetFilter.hideZeroData)
   },
   gridAssessments: (state: ApplicationState, getters: Getters) => {
-    return transforms.gridAssessments(getters.variants, state.assessments, null)
+    return transforms.gridAssessments(getters.variants, state.assessments, state.facetFilter.assessment)
   },
   gridColumns: (state: ApplicationState, getters: Getters) => {
     return transforms.gridColumns(getters.variants, state.assessments, state.facetFilter.assessment, getters.findZeroRowsAndCols, state.facetFilter.hideZeroData)

--- a/tests/unit/components/search/SearchComponent.spec.ts
+++ b/tests/unit/components/search/SearchComponent.spec.ts
@@ -41,7 +41,7 @@ describe('Search Component', () => {
         setTimeout(() => {
           expect(wrapper.emitted().searchChanged[0][0]).toEqual('dem')
           done()
-        }, 300)
+        }, 600)
       })
     })
 
@@ -55,7 +55,7 @@ describe('Search Component', () => {
         setTimeout(() => {
           expect(wrapper.emitted().searchChanged[0][0]).toEqual('')
           done()
-        }, 300)
+        }, 600)
       })
     })
 
@@ -69,7 +69,7 @@ describe('Search Component', () => {
         setTimeout(() => {
           expect(wrapper.emitted()).toEqual({})
           done()
-        }, 300)
+        }, 600)
       })
     })
   })

--- a/tests/unit/store/getters.spec.ts
+++ b/tests/unit/store/getters.spec.ts
@@ -263,7 +263,17 @@ describe('getters', () => {
     it('determines assessments for selected variants', () => {
       const state: ApplicationState = {
         ...emptyState,
-        assessments: [ assessment1A, assessment2A, assessment3A, assessment1B ]
+        assessments: [ assessment1A, assessment2A, assessment3A, assessment1B ],
+        facetFilter: {
+          assessment: [assessment1A.id, assessment2A.id],
+          hideZeroData: true,
+          gender: [],
+          subcohort: [],
+          ageGroupAt1A: [],
+          ageGroupAt2A: [],
+          ageGroupAt3A: [],
+          yearOfBirthRange: []
+        }
       }
       const gettersParam: Getters = {
         ...emptyGetters,


### PR DESCRIPTION
Include list of active assessments in call to determine grid assessments.
As a result the grid columns get filtered, and as a result of that the now empty rows get hidden

#### Checklist
- [ ] Functionality works & meets specifications
- [ ] Code reviewed
- [ ] Code unit/integration/system tested
- [ ] User documentation updated
- [ ] Conventional commits (squash if needed)
- [ ] No warnings during install
- [ ] Updated javascript typing
