### PR TITLE
fix: 364 Set file permissions on save

### DIFF
--- a/src/store/actions.ts
+++ b/src/store/actions.ts
@@ -207,8 +207,12 @@ export default {
         const newOrderResponse = await api.get(`/api/v2/lifelines_order/${state.order.orderNumber}`)
         commit('restoreOrderState', newOrderResponse)
         await setUserPermission(newOrderResponse.contents.id, 'sys_FileMeta', newOrderResponse.user, 'WRITE')
+        if (newOrderResponse.contents && newOrderResponse.contents.id) {
+          await setRolePermission(newOrderResponse.contents.id, 'sys_FileMeta', 'lifelines_MANAGER', 'WRITE')
+        }
         if (isApplicationFormUpdate) {
           await setUserPermission(newOrderResponse.applicationForm.id, 'sys_FileMeta', newOrderResponse.user, 'WRITE')
+          await setRolePermission(newOrderResponse.applicationForm.id, 'sys_FileMeta', 'lifelines_MANAGER', 'WRITE')
         }
       }
 

--- a/tests/unit/store/actions.spec.ts
+++ b/tests/unit/store/actions.spec.ts
@@ -792,6 +792,8 @@ describe('actions', () => {
         await actions.save({ state, commit, dispatch })
         expect(setUserPermission).toHaveBeenCalledWith('with-app-form', 'sys_FileMeta', 'with-app-form-user', 'WRITE')
         expect(setUserPermission).toHaveBeenCalledWith('applicationForm-id', 'sys_FileMeta', 'with-app-form-user', 'WRITE')
+        expect(setRolePermission).toHaveBeenCalledWith('with-app-form', 'sys_FileMeta', 'lifelines_MANAGER', 'WRITE')
+        expect(setRolePermission).toHaveBeenCalledWith('applicationForm-id', 'sys_FileMeta', 'lifelines_MANAGER', 'WRITE')
         done()
       })
     })


### PR DESCRIPTION
On save a new file get created for the cart ( and optionaly a new application form)
The users in the role lifelines_MANAGER should be able to read/write these files

closes #364

#### Checklist
- [ ] Functionality works & meets specifications
- [ ] Code reviewed
- [ ] Code unit/integration/system tested
- [ ] User documentation updated
- [ ] Conventional commits (squash if needed)
- [ ] No warnings during install
- [ ] Updated javascript typing
