### PR TITLE
feat: Show wiki link for subsections

### DIFF
--- a/src/components/tree/CollapsibleTree.vue
+++ b/src/components/tree/CollapsibleTree.vue
@@ -37,6 +37,9 @@
               <div class="row">
                 <div class="text-truncate col pr-2">
                   {{child.name}}
+                    <info-icon v-if="child.wiki" :id="child.name" :title="child.name" >
+                      Visit the <a :href="child.wiki" target="_blank" rel="noopener noreferrer">wiki</a> for more details
+                    </info-icon>
                 </div>
               </div>
             </li>
@@ -52,9 +55,11 @@
 import Vue from 'vue'
 import CollapseTreeIcon from '../animations/CollapseTreeIcon.vue'
 import BlockExpand from '../animations/BlockExpand.vue'
+import InfoIcon from '../InfoIcon'
 
 export default Vue.extend({
   name: 'CollapsibleTree',
+  components: { CollapseTreeIcon, BlockExpand, InfoIcon },
   props: {
     selection: {
       type: Number,
@@ -90,8 +95,7 @@ export default Vue.extend({
         this.$emit('updateopensection', id)
       }
     }
-  },
-  components: { CollapseTreeIcon, BlockExpand }
+  }
 })
 </script>
 

--- a/src/store/actions.ts
+++ b/src/store/actions.ts
@@ -101,7 +101,7 @@ export default {
     }
   }),
   loadSubSections: tryAction(async ({ commit, state }: any) => {
-    if (state.subSectionList.length === 0) {
+    if (Object.keys(state.subSectionList).length === 0) {
       const response = await api.get('/api/v2/lifelines_sub_section?num=10000')
       const subSections = transforms.subSectionList(response.items)
       commit('updateSubSections', subSections)

--- a/src/store/getters.ts
+++ b/src/store/getters.ts
@@ -133,7 +133,7 @@ export default {
     }, 0),
   treeStructure: (state: ApplicationState, getters: Getters) => {
     const loadedSection: boolean = Object.keys(state.sections).length > 0
-    const loadedSubSection: boolean = state.subSectionList.length > 0
+    const loadedSubSection: boolean = Object.keys(state.subSectionList).length > 0
     const loadedTreeStructure: boolean = state.treeStructure.length > 0
     if (loadedSection && loadedSubSection && loadedTreeStructure) {
       // return full tree

--- a/src/store/mutations.ts
+++ b/src/store/mutations.ts
@@ -10,6 +10,7 @@ import { TreeParent } from '@/types/Tree'
 import { Order, OrderState } from '@/types/Order'
 import FormField from '@/types/FormField'
 import transforms from './transforms'
+import { SubSection } from '@/types/SubSection'
 
 export default {
   setZeroDataVisibility (state: ApplicationState, visibility: boolean) {
@@ -124,7 +125,7 @@ export default {
   updateSections (state: ApplicationState, sections: {[key:number]: Section}) {
     state.sections = sections
   },
-  updateSubSections (state: ApplicationState, subSections: string[]) {
+  updateSubSections(state: ApplicationState, subSections: { [key: number]: SubSection }) {
     state.subSectionList = subSections
   },
   updateSectionTree (state: ApplicationState, sections: TreeParent[]) {

--- a/src/store/state.ts
+++ b/src/store/state.ts
@@ -86,7 +86,7 @@ const state: AppState = {
     yearOfBirthRange: []
   },
   sections: {},
-  subSectionList: [],
+  subSectionList: {},
   treeStructure: [],
   treeSelected: -1,
   treeOpenSection: -1,

--- a/src/store/transforms.ts
+++ b/src/store/transforms.ts
@@ -9,6 +9,7 @@ import { VariableWithVariants, Variable } from '@/types/Variable'
 import Variant from '@/types/Variant'
 import { RowColSet } from '@/types/Getters'
 import { sortAlphabetically } from '@/services/variableSetOrderService'
+import { SubSection } from '@/types/SubSection'
 
 const transforms:any = {}
 
@@ -35,7 +36,7 @@ transforms.cartTree = (gridSelection:GridSelection, treeStructure:any, sections:
       .filter((subsectionId) => variablesPerSubsection.hasOwnProperty(subsectionId))
       .map((subsectionId) => {
         return {
-          name: subSectionList[subsectionId],
+          name: subSectionList[subsectionId].name,
           variables: variablesPerSubsection[subsectionId]
         }
       })
@@ -186,20 +187,26 @@ transforms.sectionTree = (apiItems:any) => {
   return treeStructure
 }
 
-transforms.subSectionList = (apiItems:any) => {
-  let subSections: string[] = []
-  apiItems.map((item: any) => { subSections[item.id] = item.name })
-  return subSections
+transforms.subSectionList = (apiItems: any): { [key: number]: SubSection } => {
+  return apiItems.reduce((accum: any, item: any) => {
+    accum[item.id] = {
+      id: item.id,
+      name: item.name,
+      wiki: item.wiki
+    }
+    return accum
+  }, {})
 }
 
-transforms.treeStructure = (sectionTree:TreeParent[], sections:{ [key:number]: Section }, subSectionList: string[]) => {
+transforms.treeStructure = (sectionTree: TreeParent[], sections: { [key: number]: Section }, subSectionList: { [key: number]: SubSection }) => {
   return sectionTree.map((item: TreeParent) => {
     return {
       ...sections[item.key],
       children: item.list.map((id: number) => {
         return {
-          name: subSectionList[id],
-          id
+          name: subSectionList[id].name,
+          id,
+          wiki: subSectionList[id].wiki
         }
       })
     }

--- a/src/types/ApplicationState.ts
+++ b/src/types/ApplicationState.ts
@@ -9,6 +9,7 @@ import { TreeParent } from '@/types/Tree'
 import FormField from './FormField'
 import { Order } from './Order'
 import { Context, ContextState } from '@molgenis/molgenis-ui-context/src/types'
+import { SubSection } from './SubSection'
 
 export type Toast = {
   type?: 'danger' | 'warning' | 'success' | 'info' | 'primary' | 'secondary'
@@ -26,7 +27,7 @@ export interface AppState {
   variables: { [key:number]: Variable }
   assessments: { [key:number]: Assessment }
   sections: { [key:number]: Section }
-  subSectionList: string[]
+  subSectionList: { [key: number]: SubSection }
   toast: Toast[]
   genderOptions: FacetOption[]
   subcohortOptions: FacetOption[]

--- a/src/types/SubSection.ts
+++ b/src/types/SubSection.ts
@@ -1,0 +1,5 @@
+export interface SubSection {
+    id: number
+  name: string
+  wiki: string | null
+}

--- a/src/views/ContentView.vue
+++ b/src/views/ContentView.vue
@@ -107,7 +107,7 @@ export default Vue.extend({
     },
     selectedSubsection: function () {
       if (this.treeSelected >= 0) {
-        return this.subSectionList[this.treeSelected]
+        return this.subSectionList[this.treeSelected].name
       }
       return null
     }

--- a/tests/unit/store/actions.spec.ts
+++ b/tests/unit/store/actions.spec.ts
@@ -400,14 +400,13 @@ describe('actions', () => {
   })
 
   describe('loadSubSections', () => {
-    it('fetch the sub sections and commits them as a string list', async (done) => {
+    it('fetch the sub sections and commits a object map', async (done) => {
       const commit = jest.fn()
       await actions.loadSubSections({ state: { subSectionList: [] }, commit })
-      expect(commit).toHaveBeenCalledWith('updateSubSections', [
-        undefined, // todo refactor action to remove this undefined item
-        'sub_section1',
-        'sub_section2'
-      ])
+      expect(commit).toHaveBeenCalledWith('updateSubSections', {
+        1: { id: 1, name: 'sub_section1', wiki: undefined },
+        2: { id: 2, name: 'sub_section2', wiki: undefined }
+      })
       done()
     })
 

--- a/tests/unit/store/getters.spec.ts
+++ b/tests/unit/store/getters.spec.ts
@@ -84,7 +84,12 @@ describe('getters', () => {
         ...emptyState,
         variables: { 11: variable13, 12: variable12, 13: variable11 },
         sections: { 1: section1, 2: section2 },
-        subSectionList: ['subsection 0', 'subsection 1', 'subsection 2', 'subsection 3'],
+        subSectionList: {
+          '0': { id: 0, name: 'subsection 0', wiki: null },
+          '1': { id: 1, name: 'subsection 1', wiki: null },
+          '2': { id: 2, name: 'subsection 2', wiki: 'http:test.org' },
+          '3': { id: 3, name: 'subsection 3', wiki: null }
+        },
         treeStructure: [
           { key: 1, list: [1, 3] },
           { key: 2, list: [2] }
@@ -115,7 +120,12 @@ describe('getters', () => {
         ...emptyState,
         variables: { 11: variable11, 12: variable12, 13: variable13 },
         sections: { 1: section1, 2: section2 },
-        subSectionList: ['subsection 0', 'subsection 1', 'subsection 2', 'subsection 3'],
+        subSectionList: {
+          '0': { id: 0, name: 'subsection 0', wiki: null },
+          '1': { id: 1, name: 'subsection 1', wiki: null },
+          '2': { id: 2, name: 'subsection 2', wiki: 'http:test.org' },
+          '3': { id: 3, name: 'subsection 3', wiki: null }
+        },
         treeStructure: [
           { key: 1, list: [1, 3] },
           { key: 2, list: [2] }
@@ -508,7 +518,9 @@ describe('getters', () => {
             name: 'section'
           }
         },
-        subSectionList: ['sub-section1'],
+        subSectionList: {
+          '0': { id: 0, name: 'sub-section1', wiki: null }
+        },
         treeStructure: [{ key: 1, list: [0] }]
       }
 
@@ -516,7 +528,7 @@ describe('getters', () => {
         ...emptyGetters
       }
       it('should return the complete tree structure', () => {
-        expect(getters.treeStructure(state, gettersParam)).toEqual([{ 'children': [{ 'id': 0, 'name': 'sub-section1' }], 'id': 1, 'name': 'section' }])
+        expect(getters.treeStructure(state, gettersParam)).toEqual([{ 'children': [{ 'id': 0, 'name': 'sub-section1', wiki: null }], 'id': 1, 'name': 'section' }])
       })
     })
   })

--- a/tests/unit/store/mutations.spec.ts
+++ b/tests/unit/store/mutations.spec.ts
@@ -172,8 +172,14 @@ describe('mutations', () => {
   describe('update subsections', () => {
     it('updates subsections', () => {
       const baseAppState = { ...state }
-      mutations.updateSubSections(baseAppState, ['one', 'two'])
-      expect(baseAppState.subSectionList).toEqual(['one', 'two'])
+      mutations.updateSubSections(baseAppState, {
+        1: { id: 1, name: 'one', wiki: null },
+        2: { id: 2, name: 'two', wiki: null }
+      })
+      expect(baseAppState.subSectionList).toEqual({
+        1: { id: 1, name: 'one', wiki: null },
+        2: { id: 2, name: 'two', wiki: null }
+      })
     })
   })
   describe('update variables', () => {

--- a/tests/unit/views/ContentView.spec.ts
+++ b/tests/unit/views/ContentView.spec.ts
@@ -77,8 +77,8 @@ describe('ContentView.vue', () => {
 
     describe('and when grid variables are set and subsection selected', () => {
       beforeEach(() => {
+        store.commit('updateSubSections', [{ name: 'mySelectedSubsection', id: 0, wiki: null }])
         store.commit('updateTreeSelection', 0)
-        store.commit('updateSubSections', ['mySelectedSubsection'])
       })
       it('should show the subsection name in the i18n message', () => {
         expect(wrapper.find('.search-info').text()).toEqual('3 variable found in subsection "mySelectedSubsection".')
@@ -125,8 +125,8 @@ describe('ContentView.vue', () => {
   describe('When selectedSubselection is called', () => {
     let wrapper: any
     beforeEach(() => {
-      store.commit('updateTreeSelection', 2)
-      store.commit('updateTreeOpenSection', 5)
+      store.commit('updateTreeSelection', 0)
+      store.commit('updateTreeOpenSection', 0)
       wrapper = shallowMount(ContentView, { store, localVue })
     })
 


### PR DESCRIPTION
If the wiki contains addtional information about a subsection add a link to view the wiki data

- refactor subsection from id to object to accommodate for link info

#### Checklist
- [ ] Functionality works & meets specifications
- [ ] Code reviewed
- [ ] Code unit/integration/system tested
- [ ] User documentation updated
- [ ] Conventional commits (squash if needed)
- [ ] No warnings during install
- [ ] Updated javascript typing
