### PR TITLE
fix: add 'sec' to default selected assessments

### DIFF
--- a/src/store/actions.ts
+++ b/src/store/actions.ts
@@ -118,9 +118,9 @@ export default {
     const response = await api.get('/api/v2/lifelines_assessment')
     const assessments = transforms.assessments(response.items)
     commit('updateAssessments', assessments)
-    // All 2 char assessments filters are selected by default.
+    // All 2 char assessments and 'sec' filters are selected by default.
     const defaultActiveIds = response.items
-      .filter((assessment: Assessment) => assessment.name.length === 2)
+      .filter((assessment: Assessment) => assessment.name.length === 2 || assessment.name === 'sec')
       .map((i: any) => i.id)
     commit('assessmentsActive', defaultActiveIds)
   }),


### PR DESCRIPTION
#### Checklist
- [ ] Functionality works & meets specifications
- [ ] Code reviewed
- [ ] Code unit/integration/system tested
- [ ] User documentation updated
- [ ] Conventional commits (squash if needed)
- [ ] No warnings during install
- [ ] Updated javascript typing
