### PR TITLE
fix: Improve performance, only load vars when needed

### DIFF
--- a/src/views/CartView.vue
+++ b/src/views/CartView.vue
@@ -176,10 +176,13 @@ export default Vue.extend({
       return variableAssessmentStrings
     },
     loading () {
+      if (this.isLoading || !this.isSignedIn) {
+        return false // no data needed to show empty cart
+      }
+
       return this.isLoading || !(
         Object.keys(this.assessments).length &&
-        Object.keys(this.variables).length
-      )
+        Object.keys(this.variables).length)
     }
   }
 })

--- a/src/views/MainView.vue
+++ b/src/views/MainView.vue
@@ -48,13 +48,14 @@ export default Vue.extend({
   },
   created: async function () {
     this.setLoading(true)
-
-    const promises = Promise.all([this.loadVariables(), this.loadAssessments()])
-    await promises
-
     const orderNumber = this.$route.params.orderNumber
-    if (orderNumber && await this.loadOrderAndCart(orderNumber)) {
+    if (orderNumber) {
+      const promises = Promise.all([this.loadVariables(), this.loadAssessments()])
+      await promises
+      await this.loadOrderAndCart(orderNumber)
       this.setSuccessMessage(`Loaded order with orderNumber ${orderNumber}`)
+    } else {
+      await this.loadAssessments()
     }
     this.setLoading(false)
   }


### PR DESCRIPTION
- If user is not signed in the vars do not need to be loaded upfront, vars are loaded during section selection or search
- If the user is signed in the vars are loaded to render the cart

#### Checklist
- [ ] Functionality works & meets specifications
- [ ] Code reviewed
- [ ] Code unit/integration/system tested
- [ ] User documentation updated
- [ ] Conventional commits (squash if needed)
- [ ] No warnings during install
- [ ] Updated javascript typing
