### PR TITLE
fix: cart spinner does not hide when loading is completed

### DIFF
--- a/src/views/CartView.vue
+++ b/src/views/CartView.vue
@@ -5,7 +5,10 @@
         <div class="col-sm-12 col-md-12 col-lg-6">
           <h3 class="h4">{{$t('lifelines-webshop-cart-header')}}</h3>
 
-          <spinner-animation v-if="loading" />
+          <template v-if="loading">
+            <spinner-animation  />
+            <p class="font-italic">Fetching cart details. One moment, please..</p>
+          </template>
 
           <template v-else>
 
@@ -114,6 +117,12 @@ import ToastComponent from '@molgenis-ui/components/src/components/ToastComponen
 export default Vue.extend({
   name: 'CartView',
   components: { SpinnerAnimation, CollapseTreeIcon, ToastComponent },
+  props: {
+    isCartLoading: {
+      type: Boolean,
+      default: () => false
+    }
+  },
   data () {
     return {
       isLoading: false,
@@ -176,6 +185,9 @@ export default Vue.extend({
       return variableAssessmentStrings
     },
     loading () {
+      if (this.isCartLoading) {
+        return true
+      }
       if (this.isLoading || !this.isSignedIn) {
         return false // no data needed to show empty cart
       }

--- a/src/views/MainView.vue
+++ b/src/views/MainView.vue
@@ -9,7 +9,7 @@
             <content-view class="col"></content-view>
           </div>
           <div v-else>
-            <cart-view class="mt-3"></cart-view>
+            <cart-view class="mt-3" :isCartLoading="isCartLoading"></cart-view>
           </div>
         </div>
       </div>
@@ -33,11 +33,12 @@ export default Vue.extend({
     return {
       activeTab: 'variables',
       publicPath: process.env.BASE_URL,
-      showSidebar: true
+      showSidebar: true,
+      isCartLoading: false
     }
   },
   computed: {
-    ...mapState(['loading']),
+    ...mapState(['loading', 'variables']),
     selectedVariableIds () {
       return Object.keys(this.$store.state.gridSelection).length
     }
@@ -45,6 +46,16 @@ export default Vue.extend({
   methods: {
     ...mapMutations(['setLoading', 'setSuccessMessage']),
     ...mapActions(['loadOrderAndCart', 'loadVariables', 'loadAssessments'])
+  },
+  watch: {
+    activeTab: async function (newVal) {
+      // if the cart is shown and the variable map was not filled, load it
+      if (newVal !== 'variables' && this.selectedVariableIds && !Object.keys(this.variables).length) {
+        this.isCartLoading = true
+        await this.loadVariables().catch(() => { this.isCartLoading = false })
+        this.isCartLoading = false
+      }
+    }
   },
   created: async function () {
     this.setLoading(true)

--- a/tests/unit/views/CartView.spec.ts
+++ b/tests/unit/views/CartView.spec.ts
@@ -129,4 +129,12 @@ describe('CartView.vue', () => {
     wrapper.find('.t-toggle-all-variables').trigger('click')
     expect(wrapper.vm.$store.commit).toHaveBeenCalledWith('updateGridSelection', {})
   })
+
+  it('shows loading msg if cartLoading is set to true', async () => {
+    const propsData = {
+      isCartLoading: true
+    }
+    const wrapper = shallowMount(CartView, { stubs, localVue, mocks, propsData })
+    expect(wrapper.find('p.font-italic').text()).toEqual('Fetching cart details. One moment, please..')
+  })
 })

--- a/tests/unit/views/MainView.spec.ts
+++ b/tests/unit/views/MainView.spec.ts
@@ -20,7 +20,7 @@ describe('MainView.vue', () => {
 
   beforeEach(() => {
     Object.assign(state, {
-      state: { treeSelection: 3 },
+      state: { treeSelection: 3, gridSelection: { foo: { f: 1 }, bar: { b: 2 } } },
       toast: { type: 'danger', message: 'i am not a message' }
     })
 
@@ -63,5 +63,36 @@ describe('MainView.vue', () => {
       expect(actions.loadOrderAndCart).toHaveBeenCalledWith(expect.anything(), 'abcde', undefined)
       done()
     }, 0)
+  })
+
+  it('when the activeTab changes and vars are selected, it should call loadVariables and set isCartLoading to tue', (done) => {
+    actions.loadVariables.mockReturnValueOnce(Promise.resolve())
+    const computed = {
+      selectedVariableIds () {
+        return 12
+      }
+    }
+    const wrapper = shallowMount(MainView, {
+      store, localVue, mocks, stubs, computed })
+    wrapper.setData({ activeTab: 'selection' })
+    // @ts-ignore
+    expect(wrapper.vm.isCartLoading).toBeTruthy()
+    done()
+  })
+
+  it('when the activeTab changes and no vars are selected, isCartLoading should remain false', (done) => {
+    actions.loadVariables.mockReturnValueOnce(Promise.resolve())
+    const computed = {
+      selectedVariableIds () {
+        return 0
+      }
+    }
+    const wrapper = shallowMount(MainView, {
+      store, localVue, mocks, stubs, computed
+    })
+    wrapper.setData({ activeTab: 'selection' })
+    // @ts-ignore
+    expect(wrapper.vm.isCartLoading).toBeFalsy()
+    done()
   })
 })


### PR DESCRIPTION
Watch the active tab and show/hide loading message when appropriate

#### Checklist
- [ ] Functionality works & meets specifications
- [ ] Code reviewed
- [ ] Code unit/integration/system tested
- [ ] User documentation updated
- [ ] Conventional commits (squash if needed)
- [ ] No warnings during install
- [ ] Updated javascript typing
